### PR TITLE
chore: slack subscription attribute fix

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-03-28T08:52:14Z",
+  "generated_at": "2023-04-10T04:16:44Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesSlackAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesSlackAttributes.java
@@ -35,15 +35,6 @@ public class SubscriptionCreateAttributesSlackAttributes extends SubscriptionCre
     }
 
     /**
-     * Instantiates a new builder with required properties.
-     *
-     * @param attachmentColor the attachmentColor
-     */
-    public Builder(String attachmentColor) {
-      this.attachmentColor = attachmentColor;
-    }
-
-    /**
      * Builds a SubscriptionCreateAttributesSlackAttributes.
      *
      * @return the new SubscriptionCreateAttributesSlackAttributes instance
@@ -67,8 +58,6 @@ public class SubscriptionCreateAttributesSlackAttributes extends SubscriptionCre
   protected SubscriptionCreateAttributesSlackAttributes() { }
 
   protected SubscriptionCreateAttributesSlackAttributes(Builder builder) {
-    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.attachmentColor,
-      "attachmentColor cannot be null");
     attachmentColor = builder.attachmentColor;
   }
 

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributesSlackAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributesSlackAttributes.java
@@ -35,15 +35,6 @@ public class SubscriptionUpdateAttributesSlackAttributes extends SubscriptionUpd
     }
 
     /**
-     * Instantiates a new builder with required properties.
-     *
-     * @param attachmentColor the attachmentColor
-     */
-    public Builder(String attachmentColor) {
-      this.attachmentColor = attachmentColor;
-    }
-
-    /**
      * Builds a SubscriptionUpdateAttributesSlackAttributes.
      *
      * @return the new SubscriptionUpdateAttributesSlackAttributes instance
@@ -67,8 +58,6 @@ public class SubscriptionUpdateAttributesSlackAttributes extends SubscriptionUpd
   protected SubscriptionUpdateAttributesSlackAttributes() { }
 
   protected SubscriptionUpdateAttributesSlackAttributes(Builder builder) {
-    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.attachmentColor,
-      "attachmentColor cannot be null");
     attachmentColor = builder.attachmentColor;
   }
 

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsIT.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsIT.java
@@ -1657,12 +1657,17 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
       String slackName = "subscription_slack";
       String slackDescription = "Subscription for slack";
 
+      SubscriptionCreateAttributesSlackAttributes slackCreateAttributes = new SubscriptionCreateAttributesSlackAttributes.Builder()
+              .attachmentColor("#0000FF")
+              .build();
+
       CreateSubscriptionOptions createSlackSubscriptionOptions = new CreateSubscriptionOptions.Builder()
               .instanceId(instanceId)
               .name(slackName)
               .destinationId(destinationId4)
               .topicId(topicId)
               .description(slackDescription)
+              .attributes(slackCreateAttributes)
               .build();
 
       Response<Subscription> slackResponse = service.createSubscription(createSlackSubscriptionOptions).execute();
@@ -2224,11 +2229,16 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
       String slackName = "subscription_slack_update";
       String slackDescription = "Subscription slack update";
 
+      SubscriptionUpdateAttributesSlackAttributes slackUpdateAttributes = new SubscriptionUpdateAttributesSlackAttributes.Builder()
+      .attachmentColor("#0000FF")
+      .build();
+
       UpdateSubscriptionOptions updateSlackSubscriptionOptions = new UpdateSubscriptionOptions.Builder()
               .instanceId(instanceId)
               .id(subscriptionId8)
               .name(slackName)
               .description(slackDescription)
+              .attributes(slackUpdateAttributes)
               .build();
 
       // Invoke operation

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesSlackAttributesTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesSlackAttributesTest.java
@@ -42,10 +42,4 @@ public class SubscriptionCreateAttributesSlackAttributesTest {
     assertTrue(subscriptionCreateAttributesSlackAttributesModelNew instanceof SubscriptionCreateAttributesSlackAttributes);
     assertEquals(subscriptionCreateAttributesSlackAttributesModelNew.attachmentColor(), "testString");
   }
-
-  @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testSubscriptionCreateAttributesSlackAttributesError() throws Throwable {
-    new SubscriptionCreateAttributesSlackAttributes.Builder().build();
-  }
-
 }

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributesSlackAttributesTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributesSlackAttributesTest.java
@@ -42,10 +42,4 @@ public class SubscriptionUpdateAttributesSlackAttributesTest {
     assertTrue(subscriptionUpdateAttributesSlackAttributesModelNew instanceof SubscriptionUpdateAttributesSlackAttributes);
     assertEquals(subscriptionUpdateAttributesSlackAttributesModelNew.attachmentColor(), "testString");
   }
-
-  @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testSubscriptionUpdateAttributesSlackAttributesError() throws Throwable {
-    new SubscriptionUpdateAttributesSlackAttributes.Builder().build();
-  }
-
 }

--- a/modules/examples/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsExamples.java
+++ b/modules/examples/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsExamples.java
@@ -68,6 +68,7 @@ public class EventNotificationsExamples {
   public static String subscriptionId2 = "";
   public static String subscriptionId3 = "";
   public static String subscriptionId4 = "";
+  public static String subscriptionId5 = "";
   public static Map<String, String> config = null;
   public static String fcmServerKey = "";
   public static String fcmSenderId = "";
@@ -1148,6 +1149,27 @@ public class EventNotificationsExamples {
       Response<Subscription> sNowResponse = eventNotificationsService.createSubscription(createSNowSubscriptionOptions).execute();
       Subscription sNowSubscriptionResult = sNowResponse.getResult();
       subscriptionId4 = sNowSubscriptionResult.getId();
+
+      String slackName = "subscription_slack";
+      String slackDescription = "Subscription for slack";
+
+      SubscriptionCreateAttributesSlackAttributes slackCreateAttributes = new SubscriptionCreateAttributesSlackAttributes.Builder()
+              .attachmentColor("#0000FF")
+              .build();
+
+      CreateSubscriptionOptions createSlackSubscriptionOptions = new CreateSubscriptionOptions.Builder()
+              .instanceId(instanceId)
+              .name(slackName)
+              .destinationId(destinationId4)
+              .topicId(topicId)
+              .description(slackDescription)
+              .attributes(slackCreateAttributes)
+              .build();
+
+      Response<Subscription> slackResponse = eventNotificationsService.createSubscription(createSlackSubscriptionOptions).execute();
+
+      Subscription slackSubscriptionResult = slackResponse.getResult();
+      subscriptionId5 = slackSubscriptionResult.getId();
       // end-create_subscription
 
     } catch (ServiceResponseException e) {
@@ -1332,6 +1354,26 @@ public class EventNotificationsExamples {
       Response<Subscription> sNowResponse = eventNotificationsService.updateSubscription(updateSNowSubscriptionOptions).execute();
       Subscription sNowSubscriptionResult = sNowResponse.getResult();
       System.out.println(sNowSubscriptionResult);
+
+      String slackName = "subscription_slack_update";
+      String slackDescription = "Subscription slack update";
+      SubscriptionUpdateAttributesSlackAttributes slackUpdateAttributes = new SubscriptionUpdateAttributesSlackAttributes.Builder()
+              .attachmentColor("#0000FF")
+              .build();
+
+      UpdateSubscriptionOptions updateSlackSubscriptionOptions = new UpdateSubscriptionOptions.Builder()
+              .instanceId(instanceId)
+              .id(subscriptionId5)
+              .name(slackName)
+              .description(slackDescription)
+              .attributes(slackUpdateAttributes)
+              .build();
+
+      // Invoke operation
+      Response<Subscription> slackResponse = eventNotificationsService.updateSubscription(updateSlackSubscriptionOptions).execute();
+      Subscription slackSubscriptionResult = slackResponse.getResult();
+      System.out.println(slackSubscriptionResult);
+
       // end-update_subscription
     } catch (ServiceResponseException e) {
       logger.error(String.format("Service returned status code %s: %s%nError details: %s",
@@ -1394,6 +1436,7 @@ public class EventNotificationsExamples {
       subscriptions.add(subscriptionId1);
       subscriptions.add(subscriptionId3);
       subscriptions.add(subscriptionId4);
+      subscriptions.add(subscriptionId5);
 
       for (String subscription : subscriptions) {
         deleteSubscriptionOptions = new DeleteSubscriptionOptions.Builder()


### PR DESCRIPTION
## PR summary
At the time of subscription creation of slack, attribute attachment_color was made as mandatory which is required to be optional.

**Fixes:** https://github.ibm.com/Notification-Hub/planning/issues/8059

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
attribute attachment_color was made as mandatory which is required to be optional for slack subscription.

## What is the new behavior?  
attribute attachment_color is made optional.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->