### PR TITLE
chore: adopt java11 as min JDK for tstng package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 dist: bionic
 
 jdk:
-- openjdk8
+- openjdk11
 
 notifications:
   email: true
@@ -35,13 +35,13 @@ before_install:
 jobs:
   include:
     - stage: Build-Test
-      jdk: openjdk8
+      jdk: openjdk11
       install: true
       script:
         - build/setMavenVersion.sh
         - mvn verify -fae -DskipITs $MVN_ARGS
 
-    - jdk: openjdk11
+    - jdk: openjdk17
       install: true
       script:
         - mvn verify -fae -DskipITs $MVN_ARGS
@@ -55,7 +55,7 @@ jobs:
         - npm run semantic-release
 
     - stage: Publish-Release
-      jdk: openjdk8
+      jdk: openjdk11
       name: Publish-Javadoc
       install: true
       script:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Service Name | Artifact Coordinates
 * An [IBM Cloud][ibm-cloud-onboarding] account.
 * An Event Notifications Instance
 * An IAM API key to allow the SDK to access your account. Create one [here](https://cloud.ibm.com/iam/apikeys).
-* Java 8 or above.
+* Java 11 or above.
 
 ## Installation
 The current version of this SDK is: 0.1.13
@@ -566,6 +566,7 @@ Response<IntegrationGetResponse> response = eventNotificationsService.replaceInt
         String fcmJsonString = "{\"message\": {\"android\": {\"notification\": {\"title\": \"Alert message\",\"body\": \"Bob wants to play Poker\"},\"data\": {\"name\": \"Willie Greenholt\",\"description\": \"notification for the Poker\"}}}}";
         String apnsJsonString = "{\"alert\": \"Game Request\", \"badge\": 5 }";
         String safariJsonString = "{\"aps\":{\"alert\":{\"title\":\"FlightA998NowBoarding\",\"body\":\"BoardinghasbegunforFlightA998.\",\"action\":\"View\"},\"url-args\":[\"boarding\",\"A998\"]}}";
+        String huaweiJsonString = "{\"message\":{\"android\":{\"notification\":{\"title\":\"New Message\",\"body\":\"Hello World\",\"click_action\":{\"type\":3}}}}}";
 
         NotificationCreate body = new NotificationCreate.Builder()
         .id(InstanceID)
@@ -577,6 +578,7 @@ Response<IntegrationGetResponse> response = eventNotificationsService.replaceInt
         .time(new java.util.Date())
         .ibmenpushto(notificationDevices)
         .ibmenfcmbody(fcmJsonString)
+        .ibmenhuaweibody(huaweiJsonString)
         .ibmenapnsbody(apnsJsonString)
         .ibmensafaribody(safariJsonString)
         .ibmendefaultshort("<short-Info>")

--- a/modules/common/pom.xml
+++ b/modules/common/pom.xml
@@ -28,13 +28,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/event-notifications/pom.xml
+++ b/modules/event-notifications/pom.xml
@@ -37,16 +37,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.9</version>
@@ -59,7 +49,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.28</version>
+            <version>${slf4j-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotifications.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotifications.java
@@ -12,7 +12,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.54.0-af6d2126-20220803-151219
+ * IBM OpenAPI SDK Code Generator Version: 3.70.0-7df966bf-20230419-195904
  */
 
 package com.ibm.cloud.eventnotifications.event_notifications.v1;
@@ -84,8 +84,14 @@ import okhttp3.MultipartBody;
  */
 public class EventNotifications extends BaseService {
 
+  /**
+   * Default service name used when configuring the `EventNotifications` client.
+   */
   public static final String DEFAULT_SERVICE_NAME = "event_notifications";
 
+  /**
+   * Default service endpoint URL.
+   */
   public static final String DEFAULT_SERVICE_URL = "https://us-south.event-notifications.cloud.ibm.com/event-notifications";
 
  /**
@@ -612,7 +618,8 @@ public class EventNotifications extends BaseService {
   public ServiceCall<Destination> updateDestination(UpdateDestinationOptions updateDestinationOptions) {
     com.ibm.cloud.sdk.core.util.Validator.notNull(updateDestinationOptions,
       "updateDestinationOptions cannot be null");
-    com.ibm.cloud.sdk.core.util.Validator.isTrue((updateDestinationOptions.name() != null) || (updateDestinationOptions.description() != null) || (updateDestinationOptions.config() != null) || (updateDestinationOptions.certificate() != null) || (updateDestinationOptions.icon16x16() != null) || (updateDestinationOptions.icon16x162x() != null) || (updateDestinationOptions.icon32x32() != null) || (updateDestinationOptions.icon32x322x() != null) || (updateDestinationOptions.icon128x128() != null) || (updateDestinationOptions.icon128x1282x() != null), "At least one of name, description, config, certificate, icon16x16, icon16x162x, icon32x32, icon32x322x, icon128x128, or icon128x1282x must be supplied.");
+    com.ibm.cloud.sdk.core.util.Validator.isTrue((updateDestinationOptions.name() != null) || (updateDestinationOptions.description() != null) || (updateDestinationOptions.config() != null) || (updateDestinationOptions.certificate() != null) || (updateDestinationOptions.icon16x16() != null) || (updateDestinationOptions.icon16x162x() != null) || (updateDestinationOptions.icon32x32() != null) || (updateDestinationOptions.icon32x322x() != null) || (updateDestinationOptions.icon128x128() != null) || (updateDestinationOptions.icon128x1282x() != null),
+      "At least one of name, description, config, certificate, icon16x16, icon16x162x, icon32x32, icon32x322x, icon128x128, or icon128x1282x must be supplied.");
     Map<String, String> pathParamsMap = new HashMap<String, String>();
     pathParamsMap.put("instance_id", updateDestinationOptions.instanceId());
     pathParamsMap.put("id", updateDestinationOptions.id());

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/BulkNotificationResponse.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/BulkNotificationResponse.java
@@ -27,6 +27,8 @@ public class BulkNotificationResponse extends GenericModel {
   @SerializedName("bulk_messages")
   protected List<Object> bulkMessages;
 
+  protected BulkNotificationResponse() { }
+
   /**
    * Gets the bulkNotificationId.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateDestinationOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateDestinationOptions.java
@@ -102,6 +102,11 @@ public class CreateDestinationOptions extends GenericModel {
     private InputStream icon128x1282x;
     private String icon128x1282xContentType;
 
+    /**
+     * Instantiates a new Builder from an existing CreateDestinationOptions instance.
+     *
+     * @param createDestinationOptions the instance to initialize the Builder with
+     */
     private Builder(CreateDestinationOptions createDestinationOptions) {
       this.instanceId = createDestinationOptions.instanceId;
       this.name = createDestinationOptions.name;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateSourcesOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateSourcesOptions.java
@@ -33,6 +33,11 @@ public class CreateSourcesOptions extends GenericModel {
     private String description;
     private Boolean enabled;
 
+    /**
+     * Instantiates a new Builder from an existing CreateSourcesOptions instance.
+     *
+     * @param createSourcesOptions the instance to initialize the Builder with
+     */
     private Builder(CreateSourcesOptions createSourcesOptions) {
       this.instanceId = createSourcesOptions.instanceId;
       this.name = createSourcesOptions.name;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateSubscriptionOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateSubscriptionOptions.java
@@ -37,6 +37,11 @@ public class CreateSubscriptionOptions extends GenericModel {
     private String description;
     private SubscriptionCreateAttributes attributes;
 
+    /**
+     * Instantiates a new Builder from an existing CreateSubscriptionOptions instance.
+     *
+     * @param createSubscriptionOptions the instance to initialize the Builder with
+     */
     private Builder(CreateSubscriptionOptions createSubscriptionOptions) {
       this.instanceId = createSubscriptionOptions.instanceId;
       this.name = createSubscriptionOptions.name;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateTagsSubscriptionOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateTagsSubscriptionOptions.java
@@ -33,6 +33,11 @@ public class CreateTagsSubscriptionOptions extends GenericModel {
     private String deviceId;
     private String tagName;
 
+    /**
+     * Instantiates a new Builder from an existing CreateTagsSubscriptionOptions instance.
+     *
+     * @param createTagsSubscriptionOptions the instance to initialize the Builder with
+     */
     private Builder(CreateTagsSubscriptionOptions createTagsSubscriptionOptions) {
       this.instanceId = createTagsSubscriptionOptions.instanceId;
       this.id = createTagsSubscriptionOptions.id;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateTopicOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateTopicOptions.java
@@ -36,6 +36,11 @@ public class CreateTopicOptions extends GenericModel {
     private String description;
     private List<SourcesItems> sources;
 
+    /**
+     * Instantiates a new Builder from an existing CreateTopicOptions instance.
+     *
+     * @param createTopicOptions the instance to initialize the Builder with
+     */
     private Builder(CreateTopicOptions createTopicOptions) {
       this.instanceId = createTopicOptions.instanceId;
       this.name = createTopicOptions.name;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DeleteDestinationOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DeleteDestinationOptions.java
@@ -29,6 +29,11 @@ public class DeleteDestinationOptions extends GenericModel {
     private String instanceId;
     private String id;
 
+    /**
+     * Instantiates a new Builder from an existing DeleteDestinationOptions instance.
+     *
+     * @param deleteDestinationOptions the instance to initialize the Builder with
+     */
     private Builder(DeleteDestinationOptions deleteDestinationOptions) {
       this.instanceId = deleteDestinationOptions.instanceId;
       this.id = deleteDestinationOptions.id;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DeleteSourceOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DeleteSourceOptions.java
@@ -29,6 +29,11 @@ public class DeleteSourceOptions extends GenericModel {
     private String instanceId;
     private String id;
 
+    /**
+     * Instantiates a new Builder from an existing DeleteSourceOptions instance.
+     *
+     * @param deleteSourceOptions the instance to initialize the Builder with
+     */
     private Builder(DeleteSourceOptions deleteSourceOptions) {
       this.instanceId = deleteSourceOptions.instanceId;
       this.id = deleteSourceOptions.id;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DeleteSubscriptionOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DeleteSubscriptionOptions.java
@@ -29,6 +29,11 @@ public class DeleteSubscriptionOptions extends GenericModel {
     private String instanceId;
     private String id;
 
+    /**
+     * Instantiates a new Builder from an existing DeleteSubscriptionOptions instance.
+     *
+     * @param deleteSubscriptionOptions the instance to initialize the Builder with
+     */
     private Builder(DeleteSubscriptionOptions deleteSubscriptionOptions) {
       this.instanceId = deleteSubscriptionOptions.instanceId;
       this.id = deleteSubscriptionOptions.id;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DeleteTagsSubscriptionOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DeleteTagsSubscriptionOptions.java
@@ -33,6 +33,11 @@ public class DeleteTagsSubscriptionOptions extends GenericModel {
     private String deviceId;
     private String tagName;
 
+    /**
+     * Instantiates a new Builder from an existing DeleteTagsSubscriptionOptions instance.
+     *
+     * @param deleteTagsSubscriptionOptions the instance to initialize the Builder with
+     */
     private Builder(DeleteTagsSubscriptionOptions deleteTagsSubscriptionOptions) {
       this.instanceId = deleteTagsSubscriptionOptions.instanceId;
       this.id = deleteTagsSubscriptionOptions.id;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DeleteTopicOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DeleteTopicOptions.java
@@ -29,6 +29,11 @@ public class DeleteTopicOptions extends GenericModel {
     private String instanceId;
     private String id;
 
+    /**
+     * Instantiates a new Builder from an existing DeleteTopicOptions instance.
+     *
+     * @param deleteTopicOptions the instance to initialize the Builder with
+     */
     private Builder(DeleteTopicOptions deleteTopicOptions) {
       this.instanceId = deleteTopicOptions.instanceId;
       this.id = deleteTopicOptions.id;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/Destination.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/Destination.java
@@ -70,6 +70,8 @@ public class Destination extends GenericModel {
   @SerializedName("subscription_names")
   protected List<String> subscriptionNames;
 
+  protected Destination() { }
+
   /**
    * Gets the id.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfig.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfig.java
@@ -27,6 +27,11 @@ public class DestinationConfig extends GenericModel {
   public static class Builder {
     private DestinationConfigOneOf params;
 
+    /**
+     * Instantiates a new Builder from an existing DestinationConfig instance.
+     *
+     * @param destinationConfig the instance to initialize the Builder with
+     */
     private Builder(DestinationConfig destinationConfig) {
       this.params = destinationConfig.params;
     }

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOf.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOf.java
@@ -104,8 +104,7 @@ public class DestinationConfigOneOf extends GenericModel {
   protected String instanceId;
   protected String endpoint;
 
-  protected DestinationConfigOneOf() {
-  }
+  protected DestinationConfigOneOf() { }
 
   /**
    * Gets the url.
@@ -157,7 +156,9 @@ public class DestinationConfigOneOf extends GenericModel {
    * FCM server_key.
    *
    * @return the serverKey
+   * @deprecated this method is deprecated and may be removed in a future release
    */
+  @Deprecated
   public String serverKey() {
     return serverKey;
   }
@@ -168,7 +169,9 @@ public class DestinationConfigOneOf extends GenericModel {
    * FCM sender_id.
    *
    * @return the senderId
+   * @deprecated this method is deprecated and may be removed in a future release
    */
+  @Deprecated
   public String senderId() {
     return senderId;
   }

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfChromeDestinationConfig.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfChromeDestinationConfig.java
@@ -27,6 +27,11 @@ public class DestinationConfigOneOfChromeDestinationConfig extends DestinationCo
     private String publicKey;
     private Boolean preProd;
 
+    /**
+     * Instantiates a new Builder from an existing DestinationConfigOneOfChromeDestinationConfig instance.
+     *
+     * @param destinationConfigOneOfChromeDestinationConfig the instance to initialize the Builder with
+     */
     public Builder(DestinationConfigOneOf destinationConfigOneOfChromeDestinationConfig) {
       this.apiKey = destinationConfigOneOfChromeDestinationConfig.apiKey;
       this.websiteUrl = destinationConfigOneOfChromeDestinationConfig.websiteUrl;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfFCMDestinationConfig.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfFCMDestinationConfig.java
@@ -29,6 +29,11 @@ public class DestinationConfigOneOfFCMDestinationConfig extends DestinationConfi
     private String privateKey;
     private String clientEmail;
 
+    /**
+     * Instantiates a new Builder from an existing DestinationConfigOneOfFCMDestinationConfig instance.
+     *
+     * @param destinationConfigOneOfFcmDestinationConfig the instance to initialize the Builder with
+     */
     public Builder(DestinationConfigOneOf destinationConfigOneOfFcmDestinationConfig) {
       this.serverKey = destinationConfigOneOfFcmDestinationConfig.serverKey;
       this.senderId = destinationConfigOneOfFcmDestinationConfig.senderId;
@@ -58,7 +63,9 @@ public class DestinationConfigOneOfFCMDestinationConfig extends DestinationConfi
      *
      * @param serverKey the serverKey
      * @return the DestinationConfigOneOfFCMDestinationConfig builder
+     * @deprecated this method is deprecated and may be removed in a future release
      */
+    @Deprecated
     public Builder serverKey(String serverKey) {
       this.serverKey = serverKey;
       return this;
@@ -69,7 +76,9 @@ public class DestinationConfigOneOfFCMDestinationConfig extends DestinationConfi
      *
      * @param senderId the senderId
      * @return the DestinationConfigOneOfFCMDestinationConfig builder
+     * @deprecated this method is deprecated and may be removed in a future release
      */
+    @Deprecated
     public Builder senderId(String senderId) {
       this.senderId = senderId;
       return this;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfFirefoxDestinationConfig.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfFirefoxDestinationConfig.java
@@ -26,6 +26,11 @@ public class DestinationConfigOneOfFirefoxDestinationConfig extends DestinationC
     private String publicKey;
     private Boolean preProd;
 
+    /**
+     * Instantiates a new Builder from an existing DestinationConfigOneOfFirefoxDestinationConfig instance.
+     *
+     * @param destinationConfigOneOfFirefoxDestinationConfig the instance to initialize the Builder with
+     */
     public Builder(DestinationConfigOneOf destinationConfigOneOfFirefoxDestinationConfig) {
       this.websiteUrl = destinationConfigOneOfFirefoxDestinationConfig.websiteUrl;
       this.publicKey = destinationConfigOneOfFirefoxDestinationConfig.publicKey;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfHuaweiDestinationConfig.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfHuaweiDestinationConfig.java
@@ -26,6 +26,11 @@ public class DestinationConfigOneOfHuaweiDestinationConfig extends DestinationCo
     private String clientSecret;
     private Boolean preProd;
 
+    /**
+     * Instantiates a new Builder from an existing DestinationConfigOneOfHuaweiDestinationConfig instance.
+     *
+     * @param destinationConfigOneOfHuaweiDestinationConfig the instance to initialize the Builder with
+     */
     public Builder(DestinationConfigOneOf destinationConfigOneOfHuaweiDestinationConfig) {
       this.clientId = destinationConfigOneOfHuaweiDestinationConfig.clientId;
       this.clientSecret = destinationConfigOneOfHuaweiDestinationConfig.clientSecret;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfIBMCloudFunctionsDestinationConfig.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfIBMCloudFunctionsDestinationConfig.java
@@ -25,6 +25,11 @@ public class DestinationConfigOneOfIBMCloudFunctionsDestinationConfig extends De
     private String url;
     private String apiKey;
 
+    /**
+     * Instantiates a new Builder from an existing DestinationConfigOneOfIBMCloudFunctionsDestinationConfig instance.
+     *
+     * @param destinationConfigOneOfIbmCloudFunctionsDestinationConfig the instance to initialize the Builder with
+     */
     public Builder(DestinationConfigOneOf destinationConfigOneOfIbmCloudFunctionsDestinationConfig) {
       this.url = destinationConfigOneOfIbmCloudFunctionsDestinationConfig.url;
       this.apiKey = destinationConfigOneOfIbmCloudFunctionsDestinationConfig.apiKey;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfIBMCloudObjectStorageDestinationConfig.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfIBMCloudObjectStorageDestinationConfig.java
@@ -26,6 +26,11 @@ public class DestinationConfigOneOfIBMCloudObjectStorageDestinationConfig extend
     private String instanceId;
     private String endpoint;
 
+    /**
+     * Instantiates a new Builder from an existing DestinationConfigOneOfIBMCloudObjectStorageDestinationConfig instance.
+     *
+     * @param destinationConfigOneOfIbmCloudObjectStorageDestinationConfig the instance to initialize the Builder with
+     */
     public Builder(DestinationConfigOneOf destinationConfigOneOfIbmCloudObjectStorageDestinationConfig) {
       this.bucketName = destinationConfigOneOfIbmCloudObjectStorageDestinationConfig.bucketName;
       this.instanceId = destinationConfigOneOfIbmCloudObjectStorageDestinationConfig.instanceId;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfIOSDestinationConfig.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfIOSDestinationConfig.java
@@ -30,6 +30,11 @@ public class DestinationConfigOneOfIOSDestinationConfig extends DestinationConfi
     private String bundleId;
     private Boolean preProd;
 
+    /**
+     * Instantiates a new Builder from an existing DestinationConfigOneOfIOSDestinationConfig instance.
+     *
+     * @param destinationConfigOneOfIosDestinationConfig the instance to initialize the Builder with
+     */
     public Builder(DestinationConfigOneOf destinationConfigOneOfIosDestinationConfig) {
       this.certType = destinationConfigOneOfIosDestinationConfig.certType;
       this.isSandbox = destinationConfigOneOfIosDestinationConfig.isSandbox;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfMSTeamsDestinationConfig.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfMSTeamsDestinationConfig.java
@@ -24,6 +24,11 @@ public class DestinationConfigOneOfMSTeamsDestinationConfig extends DestinationC
   public static class Builder {
     private String url;
 
+    /**
+     * Instantiates a new Builder from an existing DestinationConfigOneOfMSTeamsDestinationConfig instance.
+     *
+     * @param destinationConfigOneOfMsTeamsDestinationConfig the instance to initialize the Builder with
+     */
     public Builder(DestinationConfigOneOf destinationConfigOneOfMsTeamsDestinationConfig) {
       this.url = destinationConfigOneOfMsTeamsDestinationConfig.url;
     }

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfPagerDutyDestinationConfig.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfPagerDutyDestinationConfig.java
@@ -25,6 +25,11 @@ public class DestinationConfigOneOfPagerDutyDestinationConfig extends Destinatio
     private String apiKey;
     private String routingKey;
 
+    /**
+     * Instantiates a new Builder from an existing DestinationConfigOneOfPagerDutyDestinationConfig instance.
+     *
+     * @param destinationConfigOneOfPagerDutyDestinationConfig the instance to initialize the Builder with
+     */
     public Builder(DestinationConfigOneOf destinationConfigOneOfPagerDutyDestinationConfig) {
       this.apiKey = destinationConfigOneOfPagerDutyDestinationConfig.apiKey;
       this.routingKey = destinationConfigOneOfPagerDutyDestinationConfig.routingKey;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfSafariDestinationConfig.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfSafariDestinationConfig.java
@@ -30,6 +30,11 @@ public class DestinationConfigOneOfSafariDestinationConfig extends DestinationCo
     private String websitePushId;
     private Boolean preProd;
 
+    /**
+     * Instantiates a new Builder from an existing DestinationConfigOneOfSafariDestinationConfig instance.
+     *
+     * @param destinationConfigOneOfSafariDestinationConfig the instance to initialize the Builder with
+     */
     public Builder(DestinationConfigOneOf destinationConfigOneOfSafariDestinationConfig) {
       this.certType = destinationConfigOneOfSafariDestinationConfig.certType;
       this.password = destinationConfigOneOfSafariDestinationConfig.password;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfServiceNowDestinationConfig.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfServiceNowDestinationConfig.java
@@ -28,6 +28,11 @@ public class DestinationConfigOneOfServiceNowDestinationConfig extends Destinati
     private String password;
     private String instanceName;
 
+    /**
+     * Instantiates a new Builder from an existing DestinationConfigOneOfServiceNowDestinationConfig instance.
+     *
+     * @param destinationConfigOneOfServiceNowDestinationConfig the instance to initialize the Builder with
+     */
     public Builder(DestinationConfigOneOf destinationConfigOneOfServiceNowDestinationConfig) {
       this.clientId = destinationConfigOneOfServiceNowDestinationConfig.clientId;
       this.clientSecret = destinationConfigOneOfServiceNowDestinationConfig.clientSecret;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfSlackDestinationConfig.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfSlackDestinationConfig.java
@@ -24,6 +24,11 @@ public class DestinationConfigOneOfSlackDestinationConfig extends DestinationCon
   public static class Builder {
     private String url;
 
+    /**
+     * Instantiates a new Builder from an existing DestinationConfigOneOfSlackDestinationConfig instance.
+     *
+     * @param destinationConfigOneOfSlackDestinationConfig the instance to initialize the Builder with
+     */
     public Builder(DestinationConfigOneOf destinationConfigOneOfSlackDestinationConfig) {
       this.url = destinationConfigOneOfSlackDestinationConfig.url;
     }

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfWebhookDestinationConfig.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfWebhookDestinationConfig.java
@@ -41,6 +41,11 @@ public class DestinationConfigOneOfWebhookDestinationConfig extends DestinationC
     private Map<String, String> customHeaders;
     private List<String> sensitiveHeaders;
 
+    /**
+     * Instantiates a new Builder from an existing DestinationConfigOneOfWebhookDestinationConfig instance.
+     *
+     * @param destinationConfigOneOfWebhookDestinationConfig the instance to initialize the Builder with
+     */
     public Builder(DestinationConfigOneOf destinationConfigOneOfWebhookDestinationConfig) {
       this.url = destinationConfigOneOfWebhookDestinationConfig.url;
       this.verb = destinationConfigOneOfWebhookDestinationConfig.verb;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationList.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationList.java
@@ -31,6 +31,8 @@ public class DestinationList extends GenericModel {
   protected PageHrefResponse previous;
   protected PageHrefResponse next;
 
+  protected DestinationList() { }
+
   /**
    * Gets the totalCount.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationListItem.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationListItem.java
@@ -68,6 +68,8 @@ public class DestinationListItem extends GenericModel {
   @SerializedName("updated_at")
   protected Date updatedAt;
 
+  protected DestinationListItem() { }
+
   /**
    * Gets the id.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationResponse.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationResponse.java
@@ -64,6 +64,8 @@ public class DestinationResponse extends GenericModel {
   @SerializedName("created_at")
   protected Date createdAt;
 
+  protected DestinationResponse() { }
+
   /**
    * Gets the id.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationTagsSubscriptionResponse.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationTagsSubscriptionResponse.java
@@ -32,6 +32,8 @@ public class DestinationTagsSubscriptionResponse extends GenericModel {
   @SerializedName("created_at")
   protected Date createdAt;
 
+  protected DestinationTagsSubscriptionResponse() { }
+
   /**
    * Gets the id.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/EmailAttributesResponseInvitedItems.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/EmailAttributesResponseInvitedItems.java
@@ -28,6 +28,8 @@ public class EmailAttributesResponseInvitedItems extends GenericModel {
   @SerializedName("expires_at")
   protected Date expiresAt;
 
+  protected EmailAttributesResponseInvitedItems() { }
+
   /**
    * Gets the email.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/EmailAttributesResponseSubscribedUnsubscribedItems.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/EmailAttributesResponseSubscribedUnsubscribedItems.java
@@ -26,6 +26,8 @@ public class EmailAttributesResponseSubscribedUnsubscribedItems extends GenericM
   @SerializedName("updated_at")
   protected Date updatedAt;
 
+  protected EmailAttributesResponseSubscribedUnsubscribedItems() { }
+
   /**
    * Gets the email.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetDestinationOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetDestinationOptions.java
@@ -29,6 +29,11 @@ public class GetDestinationOptions extends GenericModel {
     private String instanceId;
     private String id;
 
+    /**
+     * Instantiates a new Builder from an existing GetDestinationOptions instance.
+     *
+     * @param getDestinationOptions the instance to initialize the Builder with
+     */
     private Builder(GetDestinationOptions getDestinationOptions) {
       this.instanceId = getDestinationOptions.instanceId;
       this.id = getDestinationOptions.id;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetIntegrationOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetIntegrationOptions.java
@@ -29,6 +29,11 @@ public class GetIntegrationOptions extends GenericModel {
     private String instanceId;
     private String id;
 
+    /**
+     * Instantiates a new Builder from an existing GetIntegrationOptions instance.
+     *
+     * @param getIntegrationOptions the instance to initialize the Builder with
+     */
     private Builder(GetIntegrationOptions getIntegrationOptions) {
       this.instanceId = getIntegrationOptions.instanceId;
       this.id = getIntegrationOptions.id;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetSourceOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetSourceOptions.java
@@ -29,6 +29,11 @@ public class GetSourceOptions extends GenericModel {
     private String instanceId;
     private String id;
 
+    /**
+     * Instantiates a new Builder from an existing GetSourceOptions instance.
+     *
+     * @param getSourceOptions the instance to initialize the Builder with
+     */
     private Builder(GetSourceOptions getSourceOptions) {
       this.instanceId = getSourceOptions.instanceId;
       this.id = getSourceOptions.id;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetSubscriptionOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetSubscriptionOptions.java
@@ -29,6 +29,11 @@ public class GetSubscriptionOptions extends GenericModel {
     private String instanceId;
     private String id;
 
+    /**
+     * Instantiates a new Builder from an existing GetSubscriptionOptions instance.
+     *
+     * @param getSubscriptionOptions the instance to initialize the Builder with
+     */
     private Builder(GetSubscriptionOptions getSubscriptionOptions) {
       this.instanceId = getSubscriptionOptions.instanceId;
       this.id = getSubscriptionOptions.id;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetTopicOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetTopicOptions.java
@@ -31,6 +31,11 @@ public class GetTopicOptions extends GenericModel {
     private String id;
     private String include;
 
+    /**
+     * Instantiates a new Builder from an existing GetTopicOptions instance.
+     *
+     * @param getTopicOptions the instance to initialize the Builder with
+     */
     private Builder(GetTopicOptions getTopicOptions) {
       this.instanceId = getTopicOptions.instanceId;
       this.id = getTopicOptions.id;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/IntegrationGetResponse.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/IntegrationGetResponse.java
@@ -30,6 +30,8 @@ public class IntegrationGetResponse extends GenericModel {
   @SerializedName("updated_at")
   protected Date updatedAt;
 
+  protected IntegrationGetResponse() { }
+
   /**
    * Gets the id.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/IntegrationList.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/IntegrationList.java
@@ -31,6 +31,8 @@ public class IntegrationList extends GenericModel {
   protected PageHrefResponse previous;
   protected PageHrefResponse next;
 
+  protected IntegrationList() { }
+
   /**
    * Gets the totalCount.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/IntegrationListItem.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/IntegrationListItem.java
@@ -30,6 +30,8 @@ public class IntegrationListItem extends GenericModel {
   @SerializedName("updated_at")
   protected Date updatedAt;
 
+  protected IntegrationListItem() { }
+
   /**
    * Gets the id.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/IntegrationMetadata.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/IntegrationMetadata.java
@@ -33,6 +33,11 @@ public class IntegrationMetadata extends GenericModel {
     private String crn;
     private String rootKeyId;
 
+    /**
+     * Instantiates a new Builder from an existing IntegrationMetadata instance.
+     *
+     * @param integrationMetadata the instance to initialize the Builder with
+     */
     private Builder(IntegrationMetadata integrationMetadata) {
       this.endpoint = integrationMetadata.endpoint;
       this.crn = integrationMetadata.crn;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ListDestinationsOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ListDestinationsOptions.java
@@ -33,6 +33,11 @@ public class ListDestinationsOptions extends GenericModel {
     private Long offset;
     private String search;
 
+    /**
+     * Instantiates a new Builder from an existing ListDestinationsOptions instance.
+     *
+     * @param listDestinationsOptions the instance to initialize the Builder with
+     */
     private Builder(ListDestinationsOptions listDestinationsOptions) {
       this.instanceId = listDestinationsOptions.instanceId;
       this.limit = listDestinationsOptions.limit;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ListIntegrationsOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ListIntegrationsOptions.java
@@ -33,6 +33,11 @@ public class ListIntegrationsOptions extends GenericModel {
     private Long limit;
     private String search;
 
+    /**
+     * Instantiates a new Builder from an existing ListIntegrationsOptions instance.
+     *
+     * @param listIntegrationsOptions the instance to initialize the Builder with
+     */
     private Builder(ListIntegrationsOptions listIntegrationsOptions) {
       this.instanceId = listIntegrationsOptions.instanceId;
       this.offset = listIntegrationsOptions.offset;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ListSourcesOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ListSourcesOptions.java
@@ -33,6 +33,11 @@ public class ListSourcesOptions extends GenericModel {
     private Long offset;
     private String search;
 
+    /**
+     * Instantiates a new Builder from an existing ListSourcesOptions instance.
+     *
+     * @param listSourcesOptions the instance to initialize the Builder with
+     */
     private Builder(ListSourcesOptions listSourcesOptions) {
       this.instanceId = listSourcesOptions.instanceId;
       this.limit = listSourcesOptions.limit;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ListSubscriptionsOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ListSubscriptionsOptions.java
@@ -33,6 +33,11 @@ public class ListSubscriptionsOptions extends GenericModel {
     private Long limit;
     private String search;
 
+    /**
+     * Instantiates a new Builder from an existing ListSubscriptionsOptions instance.
+     *
+     * @param listSubscriptionsOptions the instance to initialize the Builder with
+     */
     private Builder(ListSubscriptionsOptions listSubscriptionsOptions) {
       this.instanceId = listSubscriptionsOptions.instanceId;
       this.offset = listSubscriptionsOptions.offset;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ListTagsSubscriptionOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ListTagsSubscriptionOptions.java
@@ -41,6 +41,11 @@ public class ListTagsSubscriptionOptions extends GenericModel {
     private Long offset;
     private String search;
 
+    /**
+     * Instantiates a new Builder from an existing ListTagsSubscriptionOptions instance.
+     *
+     * @param listTagsSubscriptionOptions the instance to initialize the Builder with
+     */
     private Builder(ListTagsSubscriptionOptions listTagsSubscriptionOptions) {
       this.instanceId = listTagsSubscriptionOptions.instanceId;
       this.id = listTagsSubscriptionOptions.id;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ListTopicsOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ListTopicsOptions.java
@@ -33,6 +33,11 @@ public class ListTopicsOptions extends GenericModel {
     private Long offset;
     private String search;
 
+    /**
+     * Instantiates a new Builder from an existing ListTopicsOptions instance.
+     *
+     * @param listTopicsOptions the instance to initialize the Builder with
+     */
     private Builder(ListTopicsOptions listTopicsOptions) {
       this.instanceId = listTopicsOptions.instanceId;
       this.limit = listTopicsOptions.limit;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/NotificationCreate.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/NotificationCreate.java
@@ -102,6 +102,11 @@ public class NotificationCreate extends DynamicModel<Object> {
     private String ibmensafaribody;
     private Map<String, Object> dynamicProperties;
 
+    /**
+     * Instantiates a new Builder from an existing NotificationCreate instance.
+     *
+     * @param notificationCreate the instance to initialize the Builder with
+     */
     private Builder(NotificationCreate notificationCreate) {
       this.specversion = notificationCreate.specversion;
       this.time = notificationCreate.time;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/NotificationResponse.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/NotificationResponse.java
@@ -23,6 +23,8 @@ public class NotificationResponse extends GenericModel {
   @SerializedName("notification_id")
   protected String notificationId;
 
+  protected NotificationResponse() { }
+
   /**
    * Gets the notificationId.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/PageHrefResponse.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/PageHrefResponse.java
@@ -21,6 +21,8 @@ public class PageHrefResponse extends GenericModel {
 
   protected String href;
 
+  protected PageHrefResponse() { }
+
   /**
    * Gets the href.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ReplaceIntegrationOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ReplaceIntegrationOptions.java
@@ -33,6 +33,11 @@ public class ReplaceIntegrationOptions extends GenericModel {
     private String type;
     private IntegrationMetadata metadata;
 
+    /**
+     * Instantiates a new Builder from an existing ReplaceIntegrationOptions instance.
+     *
+     * @param replaceIntegrationOptions the instance to initialize the Builder with
+     */
     private Builder(ReplaceIntegrationOptions replaceIntegrationOptions) {
       this.instanceId = replaceIntegrationOptions.instanceId;
       this.id = replaceIntegrationOptions.id;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ReplaceTopicOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ReplaceTopicOptions.java
@@ -38,6 +38,11 @@ public class ReplaceTopicOptions extends GenericModel {
     private String description;
     private List<SourcesItems> sources;
 
+    /**
+     * Instantiates a new Builder from an existing ReplaceTopicOptions instance.
+     *
+     * @param replaceTopicOptions the instance to initialize the Builder with
+     */
     private Builder(ReplaceTopicOptions replaceTopicOptions) {
       this.instanceId = replaceTopicOptions.instanceId;
       this.id = replaceTopicOptions.id;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/Rules.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/Rules.java
@@ -34,6 +34,11 @@ public class Rules extends GenericModel {
     private String eventTypeFilter;
     private String notificationFilter;
 
+    /**
+     * Instantiates a new Builder from an existing Rules instance.
+     *
+     * @param rules the instance to initialize the Builder with
+     */
     private Builder(Rules rules) {
       this.enabled = rules.enabled;
       this.eventTypeFilter = rules.eventTypeFilter;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/RulesGet.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/RulesGet.java
@@ -29,6 +29,8 @@ public class RulesGet extends GenericModel {
   protected String updatedAt;
   protected String id;
 
+  protected RulesGet() { }
+
   /**
    * Gets the enabled.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SMSAttributesItems.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SMSAttributesItems.java
@@ -27,6 +27,8 @@ public class SMSAttributesItems extends GenericModel {
   @SerializedName("updated_at")
   protected Date updatedAt;
 
+  protected SMSAttributesItems() { }
+
   /**
    * Gets the phoneNumber.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SMSInviteAttributesItems.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SMSInviteAttributesItems.java
@@ -29,6 +29,8 @@ public class SMSInviteAttributesItems extends GenericModel {
   @SerializedName("expires_at")
   protected Date expiresAt;
 
+  protected SMSInviteAttributesItems() { }
+
   /**
    * Gets the phoneNumber.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SendBulkNotificationsOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SendBulkNotificationsOptions.java
@@ -32,6 +32,11 @@ public class SendBulkNotificationsOptions extends GenericModel {
     private String instanceId;
     private List<NotificationCreate> bulkMessages;
 
+    /**
+     * Instantiates a new Builder from an existing SendBulkNotificationsOptions instance.
+     *
+     * @param sendBulkNotificationsOptions the instance to initialize the Builder with
+     */
     private Builder(SendBulkNotificationsOptions sendBulkNotificationsOptions) {
       this.instanceId = sendBulkNotificationsOptions.instanceId;
       this.bulkMessages = sendBulkNotificationsOptions.bulkMessages;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SendNotificationsOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SendNotificationsOptions.java
@@ -29,6 +29,11 @@ public class SendNotificationsOptions extends GenericModel {
     private String instanceId;
     private NotificationCreate body;
 
+    /**
+     * Instantiates a new Builder from an existing SendNotificationsOptions instance.
+     *
+     * @param sendNotificationsOptions the instance to initialize the Builder with
+     */
     private Builder(SendNotificationsOptions sendNotificationsOptions) {
       this.instanceId = sendNotificationsOptions.instanceId;
       this.body = sendNotificationsOptions.body;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/Source.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/Source.java
@@ -35,6 +35,8 @@ public class Source extends GenericModel {
   @SerializedName("topic_names")
   protected List<String> topicNames;
 
+  protected Source() { }
+
   /**
    * Gets the id.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SourceList.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SourceList.java
@@ -31,6 +31,8 @@ public class SourceList extends GenericModel {
   protected PageHrefResponse previous;
   protected PageHrefResponse next;
 
+  protected SourceList() { }
+
   /**
    * Gets the totalCount.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SourceListItem.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SourceListItem.java
@@ -32,6 +32,8 @@ public class SourceListItem extends GenericModel {
   @SerializedName("topic_count")
   protected Long topicCount;
 
+  protected SourceListItem() { }
+
   /**
    * Gets the id.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SourceResponse.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SourceResponse.java
@@ -29,6 +29,8 @@ public class SourceResponse extends GenericModel {
   @SerializedName("created_at")
   protected Date createdAt;
 
+  protected SourceResponse() { }
+
   /**
    * Gets the id.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SourcesItems.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SourcesItems.java
@@ -32,6 +32,11 @@ public class SourcesItems extends GenericModel {
     private String id;
     private List<Rules> rules;
 
+    /**
+     * Instantiates a new Builder from an existing SourcesItems instance.
+     *
+     * @param sourcesItems the instance to initialize the Builder with
+     */
     private Builder(SourcesItems sourcesItems) {
       this.id = sourcesItems.id;
       this.rules = sourcesItems.rules;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SourcesListItems.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SourcesListItems.java
@@ -25,6 +25,8 @@ public class SourcesListItems extends GenericModel {
   protected String name;
   protected List<RulesGet> rules;
 
+  protected SourcesListItems() { }
+
   /**
    * Gets the id.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributes.java
@@ -48,8 +48,7 @@ public class SubscriptionCreateAttributes extends GenericModel {
   @SerializedName("assignment_group")
   protected String assignmentGroup;
 
-  protected SubscriptionCreateAttributes() {
-  }
+  protected SubscriptionCreateAttributes() { }
 
   /**
    * Gets the invited.

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesEmailAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesEmailAttributes.java
@@ -31,6 +31,11 @@ public class SubscriptionCreateAttributesEmailAttributes extends SubscriptionCre
     private String replyToName;
     private String fromName;
 
+    /**
+     * Instantiates a new Builder from an existing SubscriptionCreateAttributesEmailAttributes instance.
+     *
+     * @param subscriptionCreateAttributesEmailAttributes the instance to initialize the Builder with
+     */
     public Builder(SubscriptionCreateAttributes subscriptionCreateAttributesEmailAttributes) {
       this.invited = subscriptionCreateAttributesEmailAttributes.invited;
       this.addNotificationPayload = subscriptionCreateAttributesEmailAttributes.addNotificationPayload;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesFCMAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesFCMAttributes.java
@@ -17,5 +17,7 @@ package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
  */
 public class SubscriptionCreateAttributesFCMAttributes extends SubscriptionCreateAttributes {
 
+
+  protected SubscriptionCreateAttributesFCMAttributes() { }
 }
 

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesSMSAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesSMSAttributes.java
@@ -27,6 +27,11 @@ public class SubscriptionCreateAttributesSMSAttributes extends SubscriptionCreat
   public static class Builder {
     private List<String> invited;
 
+    /**
+     * Instantiates a new Builder from an existing SubscriptionCreateAttributesSMSAttributes instance.
+     *
+     * @param subscriptionCreateAttributesSmsAttributes the instance to initialize the Builder with
+     */
     public Builder(SubscriptionCreateAttributes subscriptionCreateAttributesSmsAttributes) {
       this.invited = subscriptionCreateAttributesSmsAttributes.invited;
     }

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesServiceNowAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesServiceNowAttributes.java
@@ -25,6 +25,11 @@ public class SubscriptionCreateAttributesServiceNowAttributes extends Subscripti
     private String assignedTo;
     private String assignmentGroup;
 
+    /**
+     * Instantiates a new Builder from an existing SubscriptionCreateAttributesServiceNowAttributes instance.
+     *
+     * @param subscriptionCreateAttributesServiceNowAttributes the instance to initialize the Builder with
+     */
     public Builder(SubscriptionCreateAttributes subscriptionCreateAttributesServiceNowAttributes) {
       this.assignedTo = subscriptionCreateAttributesServiceNowAttributes.assignedTo;
       this.assignmentGroup = subscriptionCreateAttributesServiceNowAttributes.assignmentGroup;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesSlackAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesSlackAttributes.java
@@ -24,6 +24,11 @@ public class SubscriptionCreateAttributesSlackAttributes extends SubscriptionCre
   public static class Builder {
     private String attachmentColor;
 
+    /**
+     * Instantiates a new Builder from an existing SubscriptionCreateAttributesSlackAttributes instance.
+     *
+     * @param subscriptionCreateAttributesSlackAttributes the instance to initialize the Builder with
+     */
     public Builder(SubscriptionCreateAttributes subscriptionCreateAttributesSlackAttributes) {
       this.attachmentColor = subscriptionCreateAttributesSlackAttributes.attachmentColor;
     }

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesWebhookAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesWebhookAttributes.java
@@ -24,6 +24,11 @@ public class SubscriptionCreateAttributesWebhookAttributes extends SubscriptionC
   public static class Builder {
     private Boolean signingEnabled;
 
+    /**
+     * Instantiates a new Builder from an existing SubscriptionCreateAttributesWebhookAttributes instance.
+     *
+     * @param subscriptionCreateAttributesWebhookAttributes the instance to initialize the Builder with
+     */
     public Builder(SubscriptionCreateAttributes subscriptionCreateAttributesWebhookAttributes) {
       this.signingEnabled = subscriptionCreateAttributesWebhookAttributes.signingEnabled;
     }

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionList.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionList.java
@@ -31,6 +31,8 @@ public class SubscriptionList extends GenericModel {
   protected PageHrefResponse previous;
   protected PageHrefResponse next;
 
+  protected SubscriptionList() { }
+
   /**
    * Gets the totalCount.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionListItem.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionListItem.java
@@ -76,6 +76,8 @@ public class SubscriptionListItem extends GenericModel {
   @SerializedName("updated_at")
   protected Date updatedAt;
 
+  protected SubscriptionListItem() { }
+
   /**
    * Gets the id.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributes.java
@@ -47,8 +47,7 @@ public class SubscriptionUpdateAttributes extends GenericModel {
   @SerializedName("assignment_group")
   protected String assignmentGroup;
 
-  protected SubscriptionUpdateAttributes() {
-  }
+  protected SubscriptionUpdateAttributes() { }
 
   /**
    * Gets the invited.

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributesEmailUpdateAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributesEmailUpdateAttributes.java
@@ -30,6 +30,11 @@ public class SubscriptionUpdateAttributesEmailUpdateAttributes extends Subscript
     private UpdateAttributesSubscribed subscribed;
     private UpdateAttributesUnsubscribed unsubscribed;
 
+    /**
+     * Instantiates a new Builder from an existing SubscriptionUpdateAttributesEmailUpdateAttributes instance.
+     *
+     * @param subscriptionUpdateAttributesEmailUpdateAttributes the instance to initialize the Builder with
+     */
     public Builder(SubscriptionUpdateAttributes subscriptionUpdateAttributesEmailUpdateAttributes) {
       this.invited = subscriptionUpdateAttributesEmailUpdateAttributes.invited;
       this.addNotificationPayload = subscriptionUpdateAttributesEmailUpdateAttributes.addNotificationPayload;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributesSMSUpdateAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributesSMSUpdateAttributes.java
@@ -26,6 +26,11 @@ public class SubscriptionUpdateAttributesSMSUpdateAttributes extends Subscriptio
     private UpdateAttributesSubscribed subscribed;
     private UpdateAttributesUnsubscribed unsubscribed;
 
+    /**
+     * Instantiates a new Builder from an existing SubscriptionUpdateAttributesSMSUpdateAttributes instance.
+     *
+     * @param subscriptionUpdateAttributesSmsUpdateAttributes the instance to initialize the Builder with
+     */
     public Builder(SubscriptionUpdateAttributes subscriptionUpdateAttributesSmsUpdateAttributes) {
       this.invited = subscriptionUpdateAttributesSmsUpdateAttributes.invited;
       this.subscribed = subscriptionUpdateAttributesSmsUpdateAttributes.subscribed;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributesServiceNowAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributesServiceNowAttributes.java
@@ -25,6 +25,11 @@ public class SubscriptionUpdateAttributesServiceNowAttributes extends Subscripti
     private String assignedTo;
     private String assignmentGroup;
 
+    /**
+     * Instantiates a new Builder from an existing SubscriptionUpdateAttributesServiceNowAttributes instance.
+     *
+     * @param subscriptionUpdateAttributesServiceNowAttributes the instance to initialize the Builder with
+     */
     public Builder(SubscriptionUpdateAttributes subscriptionUpdateAttributesServiceNowAttributes) {
       this.assignedTo = subscriptionUpdateAttributesServiceNowAttributes.assignedTo;
       this.assignmentGroup = subscriptionUpdateAttributesServiceNowAttributes.assignmentGroup;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributesSlackAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributesSlackAttributes.java
@@ -24,6 +24,11 @@ public class SubscriptionUpdateAttributesSlackAttributes extends SubscriptionUpd
   public static class Builder {
     private String attachmentColor;
 
+    /**
+     * Instantiates a new Builder from an existing SubscriptionUpdateAttributesSlackAttributes instance.
+     *
+     * @param subscriptionUpdateAttributesSlackAttributes the instance to initialize the Builder with
+     */
     public Builder(SubscriptionUpdateAttributes subscriptionUpdateAttributesSlackAttributes) {
       this.attachmentColor = subscriptionUpdateAttributesSlackAttributes.attachmentColor;
     }

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributesWebhookAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributesWebhookAttributes.java
@@ -24,6 +24,11 @@ public class SubscriptionUpdateAttributesWebhookAttributes extends SubscriptionU
   public static class Builder {
     private Boolean signingEnabled;
 
+    /**
+     * Instantiates a new Builder from an existing SubscriptionUpdateAttributesWebhookAttributes instance.
+     *
+     * @param subscriptionUpdateAttributesWebhookAttributes the instance to initialize the Builder with
+     */
     public Builder(SubscriptionUpdateAttributes subscriptionUpdateAttributesWebhookAttributes) {
       this.signingEnabled = subscriptionUpdateAttributesWebhookAttributes.signingEnabled;
     }

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/TagsSubscriptionList.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/TagsSubscriptionList.java
@@ -32,6 +32,8 @@ public class TagsSubscriptionList extends GenericModel {
   protected PageHrefResponse previous;
   protected PageHrefResponse next;
 
+  protected TagsSubscriptionList() { }
+
   /**
    * Gets the totalCount.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/TagsSubscriptionListItem.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/TagsSubscriptionListItem.java
@@ -32,6 +32,8 @@ public class TagsSubscriptionListItem extends GenericModel {
   @SerializedName("updated_at")
   protected Date updatedAt;
 
+  protected TagsSubscriptionListItem() { }
+
   /**
    * Gets the id.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/Topic.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/Topic.java
@@ -34,6 +34,8 @@ public class Topic extends GenericModel {
   protected Long subscriptionCount;
   protected List<SubscriptionListItem> subscriptions;
 
+  protected Topic() { }
+
   /**
    * Gets the id.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/TopicList.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/TopicList.java
@@ -31,6 +31,8 @@ public class TopicList extends GenericModel {
   protected PageHrefResponse previous;
   protected PageHrefResponse next;
 
+  protected TopicList() { }
+
   /**
    * Gets the totalCount.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/TopicResponse.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/TopicResponse.java
@@ -26,6 +26,8 @@ public class TopicResponse extends GenericModel {
   @SerializedName("created_at")
   protected String createdAt;
 
+  protected TopicResponse() { }
+
   /**
    * Gets the id.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/TopicsListItem.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/TopicsListItem.java
@@ -32,6 +32,8 @@ public class TopicsListItem extends GenericModel {
   @SerializedName("subscription_count")
   protected Long subscriptionCount;
 
+  protected TopicsListItem() { }
+
   /**
    * Gets the id.
    *

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/UpdateAttributesInvited.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/UpdateAttributesInvited.java
@@ -32,6 +32,11 @@ public class UpdateAttributesInvited extends GenericModel {
     private List<String> add;
     private List<String> remove;
 
+    /**
+     * Instantiates a new Builder from an existing UpdateAttributesInvited instance.
+     *
+     * @param updateAttributesInvited the instance to initialize the Builder with
+     */
     private Builder(UpdateAttributesInvited updateAttributesInvited) {
       this.add = updateAttributesInvited.add;
       this.remove = updateAttributesInvited.remove;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/UpdateAttributesSubscribed.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/UpdateAttributesSubscribed.java
@@ -30,6 +30,11 @@ public class UpdateAttributesSubscribed extends GenericModel {
   public static class Builder {
     private List<String> remove;
 
+    /**
+     * Instantiates a new Builder from an existing UpdateAttributesSubscribed instance.
+     *
+     * @param updateAttributesSubscribed the instance to initialize the Builder with
+     */
     private Builder(UpdateAttributesSubscribed updateAttributesSubscribed) {
       this.remove = updateAttributesSubscribed.remove;
     }

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/UpdateAttributesUnsubscribed.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/UpdateAttributesUnsubscribed.java
@@ -30,6 +30,11 @@ public class UpdateAttributesUnsubscribed extends GenericModel {
   public static class Builder {
     private List<String> remove;
 
+    /**
+     * Instantiates a new Builder from an existing UpdateAttributesUnsubscribed instance.
+     *
+     * @param updateAttributesUnsubscribed the instance to initialize the Builder with
+     */
     private Builder(UpdateAttributesUnsubscribed updateAttributesUnsubscribed) {
       this.remove = updateAttributesUnsubscribed.remove;
     }

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/UpdateDestinationOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/UpdateDestinationOptions.java
@@ -68,6 +68,11 @@ public class UpdateDestinationOptions extends GenericModel {
     private InputStream icon128x1282x;
     private String icon128x1282xContentType;
 
+    /**
+     * Instantiates a new Builder from an existing UpdateDestinationOptions instance.
+     *
+     * @param updateDestinationOptions the instance to initialize the Builder with
+     */
     private Builder(UpdateDestinationOptions updateDestinationOptions) {
       this.instanceId = updateDestinationOptions.instanceId;
       this.id = updateDestinationOptions.id;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/UpdateSourceOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/UpdateSourceOptions.java
@@ -35,6 +35,11 @@ public class UpdateSourceOptions extends GenericModel {
     private String description;
     private Boolean enabled;
 
+    /**
+     * Instantiates a new Builder from an existing UpdateSourceOptions instance.
+     *
+     * @param updateSourceOptions the instance to initialize the Builder with
+     */
     private Builder(UpdateSourceOptions updateSourceOptions) {
       this.instanceId = updateSourceOptions.instanceId;
       this.id = updateSourceOptions.id;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/UpdateSubscriptionOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/UpdateSubscriptionOptions.java
@@ -35,6 +35,11 @@ public class UpdateSubscriptionOptions extends GenericModel {
     private String description;
     private SubscriptionUpdateAttributes attributes;
 
+    /**
+     * Instantiates a new Builder from an existing UpdateSubscriptionOptions instance.
+     *
+     * @param updateSubscriptionOptions the instance to initialize the Builder with
+     */
     private Builder(UpdateSubscriptionOptions updateSubscriptionOptions) {
       this.instanceId = updateSubscriptionOptions.instanceId;
       this.id = updateSubscriptionOptions.id;

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsTest.java
@@ -124,7 +124,6 @@ import com.ibm.cloud.sdk.core.security.Authenticator;
 import com.ibm.cloud.sdk.core.security.NoAuthAuthenticator;
 import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
 import com.ibm.cloud.sdk.core.util.DateUtils;
-import com.ibm.cloud.sdk.core.util.EnvironmentUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -134,10 +133,6 @@ import java.util.Map;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -146,9 +141,7 @@ import static org.testng.Assert.*;
 /**
  * Unit test class for the EventNotifications service.
  */
-@PrepareForTest({ EnvironmentUtils.class })
-@PowerMockIgnore({"javax.net.ssl.*", "org.mockito.*"})
-public class EventNotificationsTest extends PowerMockTestCase {
+public class EventNotificationsTest {
 
   final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
   final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
@@ -186,7 +179,7 @@ public class EventNotificationsTest extends PowerMockTestCase {
       .ibmendefaultshort("testString")
       .ibmendefaultlong("testString")
       .subject("testString")
-      .data(new java.util.HashMap<String, Object>() { { put("foo", "testString"); } })
+      .data(java.util.Collections.singletonMap("anyKey", "anyValue"))
       .datacontenttype("application/json")
       .ibmenpushto("{\"platforms\":[\"push_android\"]}")
       .ibmenfcmbody("testString")
@@ -265,7 +258,7 @@ public class EventNotificationsTest extends PowerMockTestCase {
       .ibmendefaultshort("testString")
       .ibmendefaultlong("testString")
       .subject("testString")
-      .data(new java.util.HashMap<String, Object>() { { put("foo", "testString"); } })
+      .data(java.util.Collections.singletonMap("anyKey", "anyValue"))
       .datacontenttype("application/json")
       .ibmenpushto("{\"platforms\":[\"push_android\"]}")
       .ibmenfcmbody("testString")
@@ -1034,7 +1027,7 @@ public class EventNotificationsTest extends PowerMockTestCase {
     DestinationConfigOneOfWebhookDestinationConfig destinationConfigOneOfModel = new DestinationConfigOneOfWebhookDestinationConfig.Builder()
       .url("testString")
       .verb("get")
-      .customHeaders(new java.util.HashMap<String, String>() { { put("foo", "testString"); } })
+      .customHeaders(java.util.Collections.singletonMap("foo", "testString"))
       .sensitiveHeaders(java.util.Arrays.asList("testString"))
       .build();
 
@@ -1291,7 +1284,7 @@ public class EventNotificationsTest extends PowerMockTestCase {
     DestinationConfigOneOfWebhookDestinationConfig destinationConfigOneOfModel = new DestinationConfigOneOfWebhookDestinationConfig.Builder()
       .url("testString")
       .verb("get")
-      .customHeaders(new java.util.HashMap<String, String>() { { put("foo", "testString"); } })
+      .customHeaders(java.util.Collections.singletonMap("foo", "testString"))
       .sensitiveHeaders(java.util.Arrays.asList("testString"))
       .build();
 
@@ -2279,17 +2272,9 @@ public class EventNotificationsTest extends PowerMockTestCase {
     eventNotificationsService = null;
   }
 
-  // Creates a mock set of environment variables that are returned by EnvironmentUtils.getenv()
-  private Map<String, String> getTestProcessEnvironment() {
-    Map<String, String> env = new HashMap<>();
-    env.put("TESTSERVICE_AUTH_TYPE", "noAuth");
-    return env;
-  }
-
   // Constructs an instance of the service to be used by the tests
   public void constructClientService() {
-    PowerMockito.spy(EnvironmentUtils.class);
-    PowerMockito.when(EnvironmentUtils.getenv()).thenReturn(getTestProcessEnvironment());
+    System.setProperty("TESTSERVICE_AUTH_TYPE", "noAuth");
     final String serviceName = "testService";
 
     eventNotificationsService = EventNotifications.newInstance(serviceName);

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateDestinationOptionsTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateDestinationOptionsTest.java
@@ -37,12 +37,12 @@ public class CreateDestinationOptionsTest {
     DestinationConfigOneOfWebhookDestinationConfig destinationConfigOneOfModel = new DestinationConfigOneOfWebhookDestinationConfig.Builder()
       .url("testString")
       .verb("get")
-      .customHeaders(new java.util.HashMap<String, String>() { { put("foo", "testString"); } })
+      .customHeaders(java.util.Collections.singletonMap("foo", "testString"))
       .sensitiveHeaders(java.util.Arrays.asList("testString"))
       .build();
     assertEquals(destinationConfigOneOfModel.url(), "testString");
     assertEquals(destinationConfigOneOfModel.verb(), "get");
-    assertEquals(destinationConfigOneOfModel.customHeaders(), new java.util.HashMap<String, String>() { { put("foo", "testString"); } });
+    assertEquals(destinationConfigOneOfModel.customHeaders(), java.util.Collections.singletonMap("foo", "testString"));
     assertEquals(destinationConfigOneOfModel.sensitiveHeaders(), java.util.Arrays.asList("testString"));
 
     DestinationConfig destinationConfigModel = new DestinationConfig.Builder()

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfWebhookDestinationConfigTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfWebhookDestinationConfigTest.java
@@ -34,12 +34,12 @@ public class DestinationConfigOneOfWebhookDestinationConfigTest {
     DestinationConfigOneOfWebhookDestinationConfig destinationConfigOneOfWebhookDestinationConfigModel = new DestinationConfigOneOfWebhookDestinationConfig.Builder()
       .url("testString")
       .verb("get")
-      .customHeaders(new java.util.HashMap<String, String>() { { put("foo", "testString"); } })
+      .customHeaders(java.util.Collections.singletonMap("foo", "testString"))
       .sensitiveHeaders(java.util.Arrays.asList("testString"))
       .build();
     assertEquals(destinationConfigOneOfWebhookDestinationConfigModel.url(), "testString");
     assertEquals(destinationConfigOneOfWebhookDestinationConfigModel.verb(), "get");
-    assertEquals(destinationConfigOneOfWebhookDestinationConfigModel.customHeaders(), new java.util.HashMap<String, String>() { { put("foo", "testString"); } });
+    assertEquals(destinationConfigOneOfWebhookDestinationConfigModel.customHeaders(), java.util.Collections.singletonMap("foo", "testString"));
     assertEquals(destinationConfigOneOfWebhookDestinationConfigModel.sensitiveHeaders(), java.util.Arrays.asList("testString"));
 
     String json = TestUtilities.serialize(destinationConfigOneOfWebhookDestinationConfigModel);

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigTest.java
@@ -35,12 +35,12 @@ public class DestinationConfigTest {
     DestinationConfigOneOfWebhookDestinationConfig destinationConfigOneOfModel = new DestinationConfigOneOfWebhookDestinationConfig.Builder()
       .url("https://1ea472c0.us-south.apigw.appdomain.cloud/nhwebhook/sendwebhook")
       .verb("post")
-      .customHeaders(new java.util.HashMap<String, String>() { { put("foo", "testString"); } })
+      .customHeaders(java.util.Collections.singletonMap("foo", "testString"))
       .sensitiveHeaders(java.util.Arrays.asList("authorization"))
       .build();
     assertEquals(destinationConfigOneOfModel.url(), "https://1ea472c0.us-south.apigw.appdomain.cloud/nhwebhook/sendwebhook");
     assertEquals(destinationConfigOneOfModel.verb(), "post");
-    assertEquals(destinationConfigOneOfModel.customHeaders(), new java.util.HashMap<String, String>() { { put("foo", "testString"); } });
+    assertEquals(destinationConfigOneOfModel.customHeaders(), java.util.Collections.singletonMap("foo", "testString"));
     assertEquals(destinationConfigOneOfModel.sensitiveHeaders(), java.util.Arrays.asList("authorization"));
 
     DestinationConfig destinationConfigModel = new DestinationConfig.Builder()

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/NotificationCreateTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/NotificationCreateTest.java
@@ -43,7 +43,7 @@ public class NotificationCreateTest {
       .ibmendefaultshort("testString")
       .ibmendefaultlong("testString")
       .subject("testString")
-      .data(new java.util.HashMap<String, Object>() { { put("foo", "testString"); } })
+      .data(java.util.Collections.singletonMap("anyKey", "anyValue"))
       .datacontenttype("application/json")
       .ibmenpushto("{\"platforms\":[\"push_android\"]}")
       .ibmenfcmbody("testString")
@@ -67,7 +67,7 @@ public class NotificationCreateTest {
     assertEquals(notificationCreateModel.getIbmendefaultshort(), "testString");
     assertEquals(notificationCreateModel.getIbmendefaultlong(), "testString");
     assertEquals(notificationCreateModel.getSubject(), "testString");
-    assertEquals(notificationCreateModel.getData(), new java.util.HashMap<String, Object>() { { put("foo", "testString"); } });
+    assertEquals(notificationCreateModel.getData(), java.util.Collections.singletonMap("anyKey", "anyValue"));
     assertEquals(notificationCreateModel.getDatacontenttype(), "application/json");
     assertEquals(notificationCreateModel.getIbmenpushto(), "{\"platforms\":[\"push_android\"]}");
     assertEquals(notificationCreateModel.getIbmenfcmbody(), "testString");
@@ -95,6 +95,7 @@ public class NotificationCreateTest {
     assertEquals(notificationCreateModelNew.getIbmendefaultshort(), "testString");
     assertEquals(notificationCreateModelNew.getIbmendefaultlong(), "testString");
     assertEquals(notificationCreateModelNew.getSubject(), "testString");
+    assertEquals(notificationCreateModelNew.getData().toString(), java.util.Collections.singletonMap("anyKey", "anyValue").toString());
     assertEquals(notificationCreateModelNew.getDatacontenttype(), "application/json");
     assertEquals(notificationCreateModelNew.getIbmenpushto(), "{\"platforms\":[\"push_android\"]}");
     assertEquals(notificationCreateModelNew.getIbmenfcmbody(), "testString");

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SendBulkNotificationsOptionsTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SendBulkNotificationsOptionsTest.java
@@ -44,7 +44,7 @@ public class SendBulkNotificationsOptionsTest {
       .ibmendefaultshort("testString")
       .ibmendefaultlong("testString")
       .subject("testString")
-      .data(new java.util.HashMap<String, Object>() { { put("foo", "testString"); } })
+      .data(java.util.Collections.singletonMap("anyKey", "anyValue"))
       .datacontenttype("application/json")
       .ibmenpushto("{\"platforms\":[\"push_android\"]}")
       .ibmenfcmbody("testString")
@@ -68,7 +68,7 @@ public class SendBulkNotificationsOptionsTest {
     assertEquals(notificationCreateModel.getIbmendefaultshort(), "testString");
     assertEquals(notificationCreateModel.getIbmendefaultlong(), "testString");
     assertEquals(notificationCreateModel.getSubject(), "testString");
-    assertEquals(notificationCreateModel.getData(), new java.util.HashMap<String, Object>() { { put("foo", "testString"); } });
+    assertEquals(notificationCreateModel.getData(), java.util.Collections.singletonMap("anyKey", "anyValue"));
     assertEquals(notificationCreateModel.getDatacontenttype(), "application/json");
     assertEquals(notificationCreateModel.getIbmenpushto(), "{\"platforms\":[\"push_android\"]}");
     assertEquals(notificationCreateModel.getIbmenfcmbody(), "testString");

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SendNotificationsOptionsTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SendNotificationsOptionsTest.java
@@ -44,7 +44,7 @@ public class SendNotificationsOptionsTest {
       .ibmendefaultshort("testString")
       .ibmendefaultlong("testString")
       .subject("testString")
-      .data(new java.util.HashMap<String, Object>() { { put("foo", "testString"); } })
+      .data(java.util.Collections.singletonMap("anyKey", "anyValue"))
       .datacontenttype("application/json")
       .ibmenpushto("{\"platforms\":[\"push_android\"]}")
       .ibmenfcmbody("testString")
@@ -68,7 +68,7 @@ public class SendNotificationsOptionsTest {
     assertEquals(notificationCreateModel.getIbmendefaultshort(), "testString");
     assertEquals(notificationCreateModel.getIbmendefaultlong(), "testString");
     assertEquals(notificationCreateModel.getSubject(), "testString");
-    assertEquals(notificationCreateModel.getData(), new java.util.HashMap<String, Object>() { { put("foo", "testString"); } });
+    assertEquals(notificationCreateModel.getData(), java.util.Collections.singletonMap("anyKey", "anyValue"));
     assertEquals(notificationCreateModel.getDatacontenttype(), "application/json");
     assertEquals(notificationCreateModel.getIbmenpushto(), "{\"platforms\":[\"push_android\"]}");
     assertEquals(notificationCreateModel.getIbmenfcmbody(), "testString");

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/UpdateDestinationOptionsTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/UpdateDestinationOptionsTest.java
@@ -37,12 +37,12 @@ public class UpdateDestinationOptionsTest {
     DestinationConfigOneOfWebhookDestinationConfig destinationConfigOneOfModel = new DestinationConfigOneOfWebhookDestinationConfig.Builder()
       .url("testString")
       .verb("get")
-      .customHeaders(new java.util.HashMap<String, String>() { { put("foo", "testString"); } })
+      .customHeaders(java.util.Collections.singletonMap("foo", "testString"))
       .sensitiveHeaders(java.util.Arrays.asList("testString"))
       .build();
     assertEquals(destinationConfigOneOfModel.url(), "testString");
     assertEquals(destinationConfigOneOfModel.verb(), "get");
-    assertEquals(destinationConfigOneOfModel.customHeaders(), new java.util.HashMap<String, String>() { { put("foo", "testString"); } });
+    assertEquals(destinationConfigOneOfModel.customHeaders(), java.util.Collections.singletonMap("foo", "testString"));
     assertEquals(destinationConfigOneOfModel.sensitiveHeaders(), java.util.Arrays.asList("testString"));
 
     DestinationConfig destinationConfigModel = new DestinationConfig.Builder()

--- a/pom.xml
+++ b/pom.xml
@@ -26,31 +26,34 @@
             of the SDK generator used to generate your SDK code.
             See this link for details: https://github.ibm.com/CloudEngineering/openapi-sdkgen/wiki/Compatibility-Chart
         -->
-        <sdk-core-version>9.15.1</sdk-core-version>
+        <sdk-core-version>9.17.5</sdk-core-version>
 
         <!-- >>> Replace this with the name of your SDK's github repository -->
         <git-repository-name>event-notifications-java-admin-sdk</git-repository-name>
 
-        <testng-version>7.4.0</testng-version>
-        <okhttp3-version>4.9.1</okhttp3-version>
-        <surefire-version>3.0.0-M3</surefire-version>
-        <jacoco-plugin-version>0.8.7</jacoco-plugin-version>
+        <testng-version>7.7.1</testng-version>
+        <okhttp3-version>4.10.0</okhttp3-version>
+        <surefire-version>3.0.0-M7</surefire-version>
+        <jacoco-plugin-version>0.8.8</jacoco-plugin-version>
         <maven-deploy-plugin-version>3.0.0-M1</maven-deploy-plugin-version>
-        <nexus-staging-plugin-version>1.6.8</nexus-staging-plugin-version>
+        <nexus-staging-plugin-version>1.6.13</nexus-staging-plugin-version>
         <maven-gpg-plugin-version>3.0.1</maven-gpg-plugin-version>
-        <maven-source-plugin-version>3.1.0</maven-source-plugin-version>
-        <maven-shade-plugin-version>3.2.2</maven-shade-plugin-version>
-        <maven-jar-plugin-version>3.2.0</maven-jar-plugin-version>
-        <maven-javadoc-plugin-version>3.1.1</maven-javadoc-plugin-version>
-        <maven-compiler-plugin-version>3.8.1</maven-compiler-plugin-version>
-        <maven-site-plugin-version>3.7.1</maven-site-plugin-version>
-        <maven-checkstyle-plugin-version>3.1.0</maven-checkstyle-plugin-version>
-        <maven-reports-plugin-version>3.0.0</maven-reports-plugin-version>
-        <maven-failsafe-plugin-version>3.0.0-M4</maven-failsafe-plugin-version>
-        <maven-buildnumber-plugin-version>1.4</maven-buildnumber-plugin-version>
-        <powermock-version>2.0.5</powermock-version>
-        <mockito-version>3.2.4</mockito-version>
-        <slf4j-version>1.7.28</slf4j-version>
+        <maven-source-plugin-version>3.2.1</maven-source-plugin-version>
+        <maven-shade-plugin-version>3.3.0</maven-shade-plugin-version>
+        <maven-jar-plugin-version>3.2.2</maven-jar-plugin-version>
+        <maven-javadoc-plugin-version>3.4.1</maven-javadoc-plugin-version>
+        <maven-compiler-plugin-version>3.10.1</maven-compiler-plugin-version>
+        <maven-site-plugin-version>3.12.1</maven-site-plugin-version>
+        <maven-checkstyle-plugin-version>3.2.0</maven-checkstyle-plugin-version>
+        <maven-reports-plugin-version>3.4.1</maven-reports-plugin-version>
+        <maven-failsafe-plugin-version>3.0.0-M7</maven-failsafe-plugin-version>
+        <maven-buildnumber-plugin-version>3.0.0</maven-buildnumber-plugin-version>
+        <slf4j-version>2.0.6</slf4j-version>
+        <java-source-version>1.8</java-source-version>
+        <java-target-version>1.8</java-target-version>
+        <min-maven-version>3.5.0</min-maven-version>
+        <min-jdk-version>11</min-jdk-version>
+        <maven-enforcer-version>3.1.0</maven-enforcer-version>
 
         <!-- versions of transitive dependencies we need to override to avoid vulnerability alerts -->
         <junit-version>4.13.2</junit-version>
@@ -164,19 +167,12 @@
                 <version>${okhttp3-version}</version>
                 <scope>test</scope>
             </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito2</artifactId>
-                <version>${powermock-version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-testng</artifactId>
-                <version>${powermock-version}</version>
-                <scope>test</scope>
-            </dependency>
             <!-- Depedency needed to build examples -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j-version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-jdk14</artifactId>
@@ -188,6 +184,31 @@
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${maven-enforcer-version}</version>
+                    <executions>
+                        <execution>
+                            <id>enforce-versions</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <requireMavenVersion>
+                                        <version>${min-maven-version}</version>
+                                        <message>Apache Maven ${min-maven-version}+ is required to build this project.</message>
+                                    </requireMavenVersion>
+                                    <requireJavaVersion>
+                                        <version>${min-jdk-version}</version>
+                                        <message>Java ${min-jdk-version}+ is required to build this project.</message>
+                                    </requireJavaVersion>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
@@ -239,8 +260,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin-version}</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <source>${java-source-version}</source>
+                        <target>${java-target-version}</target>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Signed-off-by: Nitish Kulkarni <nitish.kulkarni3@ibm.com>

## PR summary

This commit modifies the project so that java 11 is the
minimum version of the JDK for building/testing the project.
We still produce java 8-compatible classes, but using java11
will allow us to bump test-related dependencies if needed to
address security vulnerabilities.

**Fixes:** <! -- [link to issue ](https://github.ibm.com/bluemix-mobile-services/bmd-project-devops/issues/2566)-->

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
testng package is vulnerable

## What is the new behavior?  
updated org.tstng version to latest and for which minimum required java version is 11

## Does this PR introduce a breaking change?    
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This commit(https://github.ibm.com/CloudEngineering/openapi-sdkgen/commit/67404607ea87628f2936d2f76fc95945b120c169) modifies the Java generator so that we no longer
use the Powermock library within generated Java unit tests.
Specifically, the generated unit tests will simply set
a java system property instead of an environment variable
for configuring the authentication type.  This means that
we no longer need to use mocking to affect the environment and
we can simply avoid using powermock altogether.