### PR TITLE
chore: adds custom sms support

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-10-09T11:55:51Z",
+  "generated_at": "2023-11-22T08:08:44Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 language: java
-dist: bionic
+dist: jammy
 
 jdk:
 - openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ stages:
 before_install:
   - sudo apt-get update
   - env | grep TRAVIS
-  - pyenv global 3.8
+  - python -V
 
 jobs:
   include:

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ SDK Methods to consume
   - [Update Subscription](#update-subscription)
   - [Delete Subscription](#delete-subscription)
 - [Integration](#integration)
+  - [Create Integration](#create-integration)
   - [List Integrations](#list-integrations)
   - [Get Integrations](#get-integration)
   - [Update Integration](#update-integration)
@@ -457,7 +458,7 @@ supports the following templates:
 ### Create Template
 ```java
 TemplateConfig templateConfig = new TemplateConfig.Builder()
-        .body("<!DOCTYPE html><html><head><title>IBM Event Notifications</title></head><body><p>Hello! Invitation template</p><table><tr><td>Hello invitation link:{{ ibmen_invitation }} </td></tr></table></body></html>")
+        .body("base 64 encoded html content")
         .subject("Hi this is invitation for invitation message")
         .build();
 
@@ -496,11 +497,11 @@ Response<Template> response = eventNotificationsService.getTemplate(getTemplateO
 ### Update Template
 ```java
 TemplateConfig templateConfig = new TemplateConfig.Builder()
-              .body("<!DOCTYPE html><html><head><title>IBM Event Notifications</title></head><body><p>Hello! Invitation template</p><table><tr><td>Hello invitation link:{{ ibmen_invitation }} </td></tr></table></body></html>")
+              .body("base 64 encoded html content")
               .subject("Hi this is invitation for invitation message")
               .build();
 
-UpdateTemplateOptions updateTemplateInvitationOptions = new UpdateTemplateOptions.Builder()
+ReplaceTemplateOptions updateTemplateInvitationOptions = new ReplaceTemplateOptions.Builder()
         .instanceId(<instanceId>)
         .id(<templateId>)
         .name(<name>)
@@ -509,7 +510,7 @@ UpdateTemplateOptions updateTemplateInvitationOptions = new UpdateTemplateOption
         .params(templateConfig)
         .build();
 
-Response<Template> invitationResponse = eventNotificationsService.updateTemplate(updateTemplateInvitationOptions).execute();
+Response<Template> invitationResponse = eventNotificationsService.replaceTemplate(replaceTemplateInvitationOptions).execute();
 ```
 
 ### Delete Template
@@ -640,6 +641,22 @@ Response<Void> response = eventNotificationsService.deleteSubscription(deleteSub
 ```
 ## Integration
 
+### Create Integration
+```java
+IntegrationCreateMetadata metadata = new IntegrationCreateMetadata.Builder()
+        .endpoint(cosEndPoint)
+        .crn(cosInstanceCRN)
+        .bucketName(cosBucketName)
+        .build();
+
+        CreateIntegrationOptions integrationsOptions = new CreateIntegrationOptions.Builder()
+        .instanceId(instanceId)
+        .type("collect_failed_events")
+        .metadata(metadata)
+        .build();
+Response<IntegrationCreateResponse> response = service.createIntegration(integrationsOptions).execute();
+```
+
 ### Get Integration
 ```java
 GetIntegrationOptions integrationsOptions = new GetIntegrationOptions.Builder()
@@ -661,7 +678,10 @@ ListIntegrationsOptions integrationsOptions = new ListIntegrationsOptions.Builde
 Response<IntegrationList> response = eventNotificationsService.listIntegrations(integrationsOptions).execute();
 ```
 ### Update Integration
-```java
+
+
+For kms/hs-crypto- 
+```java        
 IntegrationMetadata metadata = new IntegrationMetadata.Builder()
         .endpoint("<end-point>")
         .crn("<crn>")
@@ -676,6 +696,25 @@ ReplaceIntegrationOptions integrationsOptions = new ReplaceIntegrationOptions.Bu
         .build();
         
 Response<IntegrationGetResponse> response = eventNotificationsService.replaceIntegration(integrationsOptions).execute();
+```
+
+For Cloud Object Storage-
+```java        
+IntegrationMetadata cosMetadata = new IntegrationMetadata.Builder()
+        .endpoint(cosEndPoint)
+        .crn(cosInstanceCRN)
+        .bucketName(cosBucketName)
+        .build();
+
+ReplaceIntegrationOptions cfeIntegrationsOptions = new ReplaceIntegrationOptions.Builder()
+        .instanceId(instanceId)
+        .id(cosIntegrationID)
+        .type("collect_failed_events")
+        .metadata(cosMetadata)
+        .build();
+
+// Invoke operation
+Response<IntegrationGetResponse> cfeResponse = eventNotificationsService.replaceIntegration(cfeIntegrationsOptions).execute();
 ```
 ### Send Notifications
 ```java
@@ -697,28 +736,30 @@ Response<IntegrationGetResponse> response = eventNotificationsService.replaceInt
         String safariJsonString = "{\"aps\":{\"alert\":{\"title\":\"FlightA998NowBoarding\",\"body\":\"BoardinghasbegunforFlightA998.\",\"action\":\"View\"},\"url-args\":[\"boarding\",\"A998\"]}}";
         String huaweiJsonString = "{\"message\":{\"android\":{\"notification\":{\"title\":\"New Message\",\"body\":\"Hello World\",\"click_action\":{\"type\":3}}}}}";
         String mailTo = "[\"abc@ibm.com\", \"def@us.ibm.com\"]";
+        String smsTo = "[\"+911234567890\", \"+911224567890\"]";
         String htmlBody = "\"Hi  ,<br/>Certificate expiring in 90 days.<br/><br/>Please login to <a href=\"https: //cloud.ibm.com/security-compliance/dashboard\">Security and Complaince dashboard</a> to find more information<br/>\"";
         
         NotificationCreate body = new NotificationCreate.Builder()
-        .id(InstanceID)
-        .ibmenseverity("<notification-severity>")
-        .id("<notification-id>")
-        .source("<source-id>")
-        .ibmensourceid("<source-id>")
-        .type("<notification-type>")
-        .time(new java.util.Date())
-        .ibmensubject("<subject>")
-        .ibmenmailto(mailTo)
-        .ibmenhtmlbody(htmlBody)
-        .ibmenpushto(notificationDevices)
-        .ibmenfcmbody(fcmJsonString)
-        .ibmenhuaweibody(huaweiJsonString)
-        .ibmenapnsbody(apnsJsonString)
-        .ibmensafaribody(safariJsonString)
-        .ibmendefaultshort("<short-Info>")
-        .ibmendefaultlong("<long-Info>")
-        .specversion("1.0")
-        .build();
+              .id(InstanceID)
+              .ibmenseverity("<notification-severity>")
+              .id("<notification-id>")
+              .source("<source-id>")
+              .ibmensourceid("<source-id>")
+              .type("<notification-type>")
+              .time(new java.util.Date())
+              .ibmensubject("<subject>")
+              .ibmenmailto(mailTo)
+              .ibmensmsto(smsTo)
+              .ibmenhtmlbody(htmlBody)
+              .ibmenpushto(notificationDevices)
+              .ibmenfcmbody(fcmJsonString)
+              .ibmenhuaweibody(huaweiJsonString)
+              .ibmenapnsbody(apnsJsonString)
+              .ibmensafaribody(safariJsonString)
+              .ibmendefaultshort("<short-Info>")
+              .ibmendefaultlong("<long-Info>")
+              .specversion("1.0")
+              .build();
 
         SendNotificationsOptions sendNotificationsOptions = new SendNotificationsOptions.Builder()
         .instanceId(instanceId)
@@ -734,37 +775,45 @@ Response<IntegrationGetResponse> response = eventNotificationsService.replaceInt
 <br>
 
 - **ibmenpushto** - Set up the push notifications targets.
-  - *fcm_devices* (Array of **String**) - Send notification to the list of specified Android devices.
-  - *fcm_devices* (Array of **String**) - Send notification to the list of specified iOS devices.
-  - *_devices* (Array of **String**) - Send notification to the list of specified Chrome devices.
-  - *firefox_devices* (Array of **String**) - Send notification to the list of specified Firefox devices.
-  - *tags* (Array of **String**) - Send notification to the devices that have subscribed to any of these tags.
-  - *platforms* (Array of **String**) - Send notification to the devices of the specified platforms.
+  - **user_ids** (_Array of String_) - Send notification to the specified userIds.
+  - **fcm_devices** (_Array of String_) - Send notification to the list of specified Android devices.
+  - **apns_devices** (_Array of String_) - Send notification to the list of specified iOS devices.
+  - **chrome_devices** (_Array of String_) - Send notification to the list of specified Chrome devices.
+  - **firefox_devices** (_Array of string_) - Send notification to the list of specified Firefox devices.
+  - **tags** (_Array of string_) - Send notification to the devices that have subscribed to any of these tags.
+  - **platforms** (_Array of string_) - Send notification to the devices of the specified platforms.
     - Pass 'G' for google (Android) devices.
     - Pass 'A' for iOS devices.
     - Pass 'WEB_FIREFOX' for Firefox browser.
     - Pass 'WEB_CHROME' for Chrome browser.
-**Event Notifications SendNotificationsOptions** - Event Notifications Send Notifications method.
-  - *InstanceID* (**String**) - Event Notifications instance AppGUID.
-  - *ibmenseverity* (**String**) - Severity for the notifications. Some sources can have the concept of an Event severity. Hence a handy way is provided to specify a severity of the event.
-  - *id* (**String**) - A unique identifier that identifies each event. source+id must be unique. The backend should be able to uniquely track this id in logs and other records. Send unique ID for each send notification. Same ID can be sent in case of failure of send notification. source+id will be logged in IBM Cloud Logging service. Using this combination we will be able to trace the event movement from one system to another and will aid in debugging and tracing.
-  - *source* (**String**) - This is the identifier of the event producer. A way to uniquely identify the source of the event. For IBM Cloud services this is the crn of the service instance producing the events. For API sources this can be something the event producer backend can uniquely identify itself with.
-  - *ibmensourceid* (**String**) - This is the ID of the source created in EN. This is available in the EN UI in the "Sources" section.
-  - *type* (**String**) - This describes the type of event. It is of the form <event-type-name>:<sub-type> This type is defined by the producer. The event type name has to be prefixed with the reverse DNS names so the event type is uniquely identified. The same event type can be produced by 2 different sources. It is highly recommended to use hyphen - as a separator instead of _.
-  - *time* (**String**) - Time of the notifications. UTC time stamp when the event occurred. Must be in the RFC 3339 format.
-  - *ibmenpushto* (**string**) - Targets for the FCM notifications. This contains details about the destination where you want to send push notification. This attribute is mandatory for successful delivery from an Android FCM or APNS destination
-  - *ibmenfcmbody* (**string**) - Set payload string specific to Android platform [Refer this FCM official [link](https://firebase.google.com/docs/cloud-messaging/http-server-ref#notification-payload-support)].
-  - *ibmenapnsbody* (**string**) - Set payload string specific to iOS platform [Refer this APNs official doc [link](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html)].
-  - *ibmenapnsheaders* (**string**) - Set headers required for the APNs message [Refer this APNs official [link](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns)(Table 1 Header fields for a POST request)]
-  - *ibmenchromebody* (**string**) - Message body for the Chrome notifications. Refer [this official documentation](https://developer.mozilla.org/en-US/docs/Web/API/Notification/Notification) for more.
-  - *ibmenfirefoxbody* (**string**) - Message body for the Firefox notifications. Refer [this official documentation](https://developer.mozilla.org/en-US/docs/Web/API/Notification/Notification) for more.
-  - *ibmensafaribody* (**string**) - Set payload string specific to safari notifications [Refer this Safari official doc [link](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html)].
-  - *ibmenchromeheaders* (**string**) - Headers for the Chrome notifications. Refer [this official documentation](https://developer.mozilla.org/en-US/docs/Web/API/Notification/Notification) for more.
-  - *ibmenfirefoxheaders* (**string**) - Headers for the Firefox notifications. Refer [this official documentation](https://developer.mozilla.org/en-US/docs/Web/API/Notification/Notification) for more.
-  - *ibmendefaultshort* (**string**) - Default short text for the message.
-  - *ibmendefaultlong* (**string**) - Default long text for the message.
-  - *specversion* (**String**) - Spec version of the Event Notifications. Default value is `1.0`.
+- **Event Notifications SendNotificationsOptions** - Event Notifications Send Notifications method.
+  - **instance_id** (_string_) - Unique identifier for IBM Cloud Event Notifications instance.
+  - **ibmenseverity** (_string_) - Severity for the notifications. Some sources can have the concept of an Event severity. Hence a handy way is provided to specify a severity of the event. example: LOW, HIGH, MEDIUM
+  - **id*** (_string_) - A unique identifier that identifies each event. source+id must be unique. The backend should be able to uniquely track this id in logs and other records. Send unique ID for each send notification. Same ID can be sent in case of failure of send notification. source+id will be logged in IBM Cloud Logging service. Using this combination we will be able to trace the event movement from one system to another and will aid in debugging and tracing.
+  - **source*** (_string_) - Source of the notifications. This is the identifier of the event producer. A way to uniquely identify the source of the event. For IBM Cloud services this is the crn of the service instance producing the events. For API sources this can be something the event producer backend can uniquely identify itself with.
+  - **ibmensourceid*** (_string_) - This is the ID of the source created in EN. This is available in the EN UI in the "Sources" section.
+  - **type** (_string_) - This describes the type of event. It is of the form <event-type-name>:<sub-type> This type is defined by the producer. The event type name has to be prefixed with the reverse DNS names so the event type is uniquely identified. The same event type can be produced by 2 different sources. It is highly recommended to use hyphen - as a separator instead of _.
+  - **data** (_string_) - The payload for webhook notification. If data is added as part of payload then its mandatory to add **datacontenttype**.
+  - **datacontenttype** - The notification content type. example: application/json
+  - **time** (_string_) - Time of the notifications. UTC time stamp when the event occurred. Must be in the RFC 3339 format.
+  - **ibmenpushto** (_string_) - Targets for the FCM notifications. This contains details about the destination where you want to send push notification. This attribute is mandatory for successful delivery from an Android FCM or APNS destination.
+  - **ibmenfcmbody** (_string_) - Set payload string specific to Android platform [Refer this FCM official [link](https://firebase.google.com/docs/cloud-messaging/http-server-ref#notification-payload-support)].
+  - **ibmenhuaweibody** (_string_) - Set payload string specific to Android platform [Refer this FCM official [link](https://firebase.google.com/docs/cloud-messaging/http-server-ref#notification-payload-support)].
+  - **ibmenapnsbody** (_string_) - Set payload string specific to iOS platform [Refer this APNs official doc [link](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html)].
+  - **ibmensafaribody** (_string_) - Set payload string specific to safari platform [Refer this Safari official doc [link](https://developer.huawei.com/consumer/en/hms/huawei-pushkit)].
+  - **ibmenapnsheaders** (_string_) - Set headers required for the APNs message [Refer this APNs official [link](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns)(Table 1 Header fields for a POST request)]
+  - **ibmenchromebody** (_string_) - Message body for the Chrome notifications. Refer [this official documentation](https://developer.mozilla.org/en-US/docs/Web/API/Notification/Notification) for more.
+  - **ibmenfirefoxbody** (_string_) - Message body for the Firefox notifications. Refer [this official documentation](https://developer.mozilla.org/en-US/docs/Web/API/Notification/Notification) for more.
+  - **ibmenchromeheaders** (_string_) - Headers for the Chrome notifications. Refer [this official documentation](https://developer.mozilla.org/en-US/docs/Web/API/Notification/Notification) for more.
+  - **ibmenfirefoxheaders** (_string_) - Headers for the Firefox notifications. Refer [this official documentation](https://developer.mozilla.org/en-US/docs/Web/API/Notification/Notification) for more.
+  - **ibmendefaultshort*** (_string_) - Default short text for the message.
+  - **ibmendefaultlong*** (_string_) - Default long text for the message.
+  - **specversion*** (_string_) - Spec version of the Event Notifications. Default value is `1.0`.
+  - **ibmenhtmlbody*** (_string_) - The html body of notification for email.
+  - **ibmenmailto*** (_Array of string_) - Array of email ids to which the notification to be sent.
+  - **ibmensmsto*** (_Array of string_) - Array of SMS numbers to which the notification to be sent.
 
+Note: variable with * represents the mandatory attribute.
 </details>
 
 ## Set Environment

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotifications.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotifications.java
@@ -21,6 +21,7 @@ import com.google.gson.JsonObject;
 import com.ibm.cloud.event_notifications.common.SdkCommon;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.BulkNotificationResponse;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.CreateDestinationOptions;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.CreateIntegrationOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.CreateSourcesOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.CreateSubscriptionOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.CreateTagsSubscriptionOptions;
@@ -36,12 +37,15 @@ import com.ibm.cloud.eventnotifications.event_notifications.v1.model.Destination
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.DestinationList;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.DestinationResponse;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.DestinationTagsSubscriptionResponse;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.EnabledCountriesResponse;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.GetDestinationOptions;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.GetEnabledCountriesOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.GetIntegrationOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.GetSourceOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.GetSubscriptionOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.GetTemplateOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.GetTopicOptions;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.IntegrationCreateResponse;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.IntegrationGetResponse;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.IntegrationList;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.ListDestinationsOptions;
@@ -53,6 +57,7 @@ import com.ibm.cloud.eventnotifications.event_notifications.v1.model.ListTemplat
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.ListTopicsOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.NotificationResponse;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.ReplaceIntegrationOptions;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.ReplaceTemplateOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.ReplaceTopicOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SendBulkNotificationsOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SendNotificationsOptions;
@@ -73,7 +78,6 @@ import com.ibm.cloud.eventnotifications.event_notifications.v1.model.TopicRespon
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.UpdateDestinationOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.UpdateSourceOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.UpdateSubscriptionOptions;
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.UpdateTemplateOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.UpdateVerifyDestinationOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.VerificationResponse;
 import com.ibm.cloud.sdk.core.http.RequestBuilder;
@@ -593,33 +597,33 @@ public class EventNotifications extends BaseService {
    *
    * Update details of a Template.
    *
-   * @param updateTemplateOptions the {@link UpdateTemplateOptions} containing the options for the call
+   * @param replaceTemplateOptions the {@link ReplaceTemplateOptions} containing the options for the call
    * @return a {@link ServiceCall} with a result of type {@link Template}
    */
-  public ServiceCall<Template> updateTemplate(UpdateTemplateOptions updateTemplateOptions) {
-    com.ibm.cloud.sdk.core.util.Validator.notNull(updateTemplateOptions,
-      "updateTemplateOptions cannot be null");
+  public ServiceCall<Template> replaceTemplate(ReplaceTemplateOptions replaceTemplateOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(replaceTemplateOptions,
+      "replaceTemplateOptions cannot be null");
     Map<String, String> pathParamsMap = new HashMap<String, String>();
-    pathParamsMap.put("instance_id", updateTemplateOptions.instanceId());
-    pathParamsMap.put("id", updateTemplateOptions.id());
+    pathParamsMap.put("instance_id", replaceTemplateOptions.instanceId());
+    pathParamsMap.put("id", replaceTemplateOptions.id());
     RequestBuilder builder = RequestBuilder.put(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/instances/{instance_id}/templates/{id}", pathParamsMap));
-    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("event_notifications", "v1", "updateTemplate");
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("event_notifications", "v1", "replaceTemplate");
     for (Entry<String, String> header : sdkHeaders.entrySet()) {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
     final JsonObject contentJson = new JsonObject();
-    if (updateTemplateOptions.name() != null) {
-      contentJson.addProperty("name", updateTemplateOptions.name());
+    if (replaceTemplateOptions.name() != null) {
+      contentJson.addProperty("name", replaceTemplateOptions.name());
     }
-    if (updateTemplateOptions.description() != null) {
-      contentJson.addProperty("description", updateTemplateOptions.description());
+    if (replaceTemplateOptions.description() != null) {
+      contentJson.addProperty("description", replaceTemplateOptions.description());
     }
-    if (updateTemplateOptions.type() != null) {
-      contentJson.addProperty("type", updateTemplateOptions.type());
+    if (replaceTemplateOptions.type() != null) {
+      contentJson.addProperty("type", replaceTemplateOptions.type());
     }
-    if (updateTemplateOptions.params() != null) {
-      contentJson.add("params", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(updateTemplateOptions.params()));
+    if (replaceTemplateOptions.params() != null) {
+      contentJson.add("params", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(replaceTemplateOptions.params()));
     }
     builder.bodyJson(contentJson);
     ResponseConverter<Template> responseConverter =
@@ -651,31 +655,6 @@ public class EventNotifications extends BaseService {
   }
 
   /**
-   * Test a destination.
-   *
-   * Test a destination.
-   *
-   * @param testDestinationOptions the {@link TestDestinationOptions} containing the options for the call
-   * @return a {@link ServiceCall} with a result of type {@link TestDestinationResponse}
-   */
-  public ServiceCall<TestDestinationResponse> testDestination(TestDestinationOptions testDestinationOptions) {
-    com.ibm.cloud.sdk.core.util.Validator.notNull(testDestinationOptions,
-      "testDestinationOptions cannot be null");
-    Map<String, String> pathParamsMap = new HashMap<String, String>();
-    pathParamsMap.put("instance_id", testDestinationOptions.instanceId());
-    pathParamsMap.put("id", testDestinationOptions.id());
-    RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/instances/{instance_id}/destinations/{id}/test", pathParamsMap));
-    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("event_notifications", "v1", "testDestination");
-    for (Entry<String, String> header : sdkHeaders.entrySet()) {
-      builder.header(header.getKey(), header.getValue());
-    }
-    builder.header("Accept", "application/json");
-    ResponseConverter<TestDestinationResponse> responseConverter =
-      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<TestDestinationResponse>() { }.getType());
-    return createServiceCall(builder.build(), responseConverter);
-  }
-
-  /**
    * Create a new Destination.
    *
    * Create a new Destination.
@@ -700,6 +679,9 @@ public class EventNotifications extends BaseService {
     multipartBuilder.addFormDataPart("type", createDestinationOptions.type());
     if (createDestinationOptions.description() != null) {
       multipartBuilder.addFormDataPart("description", createDestinationOptions.description());
+    }
+    if (createDestinationOptions.collectFailedEvents() != null) {
+      multipartBuilder.addFormDataPart("collect_failed_events", String.valueOf(createDestinationOptions.collectFailedEvents()));
     }
     if (createDestinationOptions.config() != null) {
       multipartBuilder.addFormDataPart("config", createDestinationOptions.config().toString());
@@ -807,8 +789,8 @@ public class EventNotifications extends BaseService {
   public ServiceCall<Destination> updateDestination(UpdateDestinationOptions updateDestinationOptions) {
     com.ibm.cloud.sdk.core.util.Validator.notNull(updateDestinationOptions,
       "updateDestinationOptions cannot be null");
-    com.ibm.cloud.sdk.core.util.Validator.isTrue((updateDestinationOptions.name() != null) || (updateDestinationOptions.description() != null) || (updateDestinationOptions.config() != null) || (updateDestinationOptions.certificate() != null) || (updateDestinationOptions.icon16x16() != null) || (updateDestinationOptions.icon16x162x() != null) || (updateDestinationOptions.icon32x32() != null) || (updateDestinationOptions.icon32x322x() != null) || (updateDestinationOptions.icon128x128() != null) || (updateDestinationOptions.icon128x1282x() != null),
-      "At least one of name, description, config, certificate, icon16x16, icon16x162x, icon32x32, icon32x322x, icon128x128, or icon128x1282x must be supplied.");
+    com.ibm.cloud.sdk.core.util.Validator.isTrue((updateDestinationOptions.name() != null) || (updateDestinationOptions.description() != null) || (updateDestinationOptions.collectFailedEvents() != null) || (updateDestinationOptions.config() != null) || (updateDestinationOptions.certificate() != null) || (updateDestinationOptions.icon16x16() != null) || (updateDestinationOptions.icon16x162x() != null) || (updateDestinationOptions.icon32x32() != null) || (updateDestinationOptions.icon32x322x() != null) || (updateDestinationOptions.icon128x128() != null) || (updateDestinationOptions.icon128x1282x() != null),
+      "At least one of name, description, collectFailedEvents, config, certificate, icon16x16, icon16x162x, icon32x32, icon32x322x, icon128x128, or icon128x1282x must be supplied.");
     Map<String, String> pathParamsMap = new HashMap<String, String>();
     pathParamsMap.put("instance_id", updateDestinationOptions.instanceId());
     pathParamsMap.put("id", updateDestinationOptions.id());
@@ -825,6 +807,9 @@ public class EventNotifications extends BaseService {
     }
     if (updateDestinationOptions.description() != null) {
       multipartBuilder.addFormDataPart("description", updateDestinationOptions.description());
+    }
+    if (updateDestinationOptions.collectFailedEvents() != null) {
+      multipartBuilder.addFormDataPart("collect_failed_events", String.valueOf(updateDestinationOptions.collectFailedEvents()));
     }
     if (updateDestinationOptions.config() != null) {
       multipartBuilder.addFormDataPart("config", updateDestinationOptions.config().toString());
@@ -883,6 +868,56 @@ public class EventNotifications extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     ResponseConverter<Void> responseConverter = ResponseConverterUtils.getVoid();
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Get enabled country details of SMS destination.
+   *
+   * Get enabled country details of SMS destination.
+   *
+   * @param getEnabledCountriesOptions the {@link GetEnabledCountriesOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link EnabledCountriesResponse}
+   */
+  public ServiceCall<EnabledCountriesResponse> getEnabledCountries(GetEnabledCountriesOptions getEnabledCountriesOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(getEnabledCountriesOptions,
+      "getEnabledCountriesOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("instance_id", getEnabledCountriesOptions.instanceId());
+    pathParamsMap.put("id", getEnabledCountriesOptions.id());
+    RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/instances/{instance_id}/destinations/{id}/enabled_countries", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("event_notifications", "v1", "getEnabledCountries");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    ResponseConverter<EnabledCountriesResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<EnabledCountriesResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Test a Destination.
+   *
+   * Test a Destination.
+   *
+   * @param testDestinationOptions the {@link TestDestinationOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link TestDestinationResponse}
+   */
+  public ServiceCall<TestDestinationResponse> testDestination(TestDestinationOptions testDestinationOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(testDestinationOptions,
+      "testDestinationOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("instance_id", testDestinationOptions.instanceId());
+    pathParamsMap.put("id", testDestinationOptions.id());
+    RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/instances/{instance_id}/destinations/{id}/test", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("event_notifications", "v1", "testDestination");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    ResponseConverter<TestDestinationResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<TestDestinationResponse>() { }.getType());
     return createServiceCall(builder.build(), responseConverter);
   }
 
@@ -1166,6 +1201,34 @@ public class EventNotifications extends BaseService {
   }
 
   /**
+   * Create an Integration.
+   *
+   * Create an Integration.
+   *
+   * @param createIntegrationOptions the {@link CreateIntegrationOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link IntegrationCreateResponse}
+   */
+  public ServiceCall<IntegrationCreateResponse> createIntegration(CreateIntegrationOptions createIntegrationOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(createIntegrationOptions,
+      "createIntegrationOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("instance_id", createIntegrationOptions.instanceId());
+    RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/instances/{instance_id}/integrations", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("event_notifications", "v1", "createIntegration");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    final JsonObject contentJson = new JsonObject();
+    contentJson.addProperty("type", createIntegrationOptions.type());
+    contentJson.add("metadata", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(createIntegrationOptions.metadata()));
+    builder.bodyJson(contentJson);
+    ResponseConverter<IntegrationCreateResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<IntegrationCreateResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
    * List all Integrations.
    *
    * List of all KMS Integrations.
@@ -1226,7 +1289,7 @@ public class EventNotifications extends BaseService {
   /**
    * Update an existing Integration.
    *
-   * Update an existing KMS Integration.
+   * Update an existing Integration.
    *
    * @param replaceIntegrationOptions the {@link ReplaceIntegrationOptions} containing the options for the call
    * @return a {@link ServiceCall} with a result of type {@link IntegrationGetResponse}

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateDestinationOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateDestinationOptions.java
@@ -58,12 +58,15 @@ public class CreateDestinationOptions extends GenericModel {
     String PUSH_HUAWEI = "push_huawei";
     /** smtp_custom. */
     String SMTP_CUSTOM = "smtp_custom";
+    /** sms_custom. */
+    String SMS_CUSTOM = "sms_custom";
   }
 
   protected String instanceId;
   protected String name;
   protected String type;
   protected String description;
+  protected Boolean collectFailedEvents;
   protected DestinationConfig config;
   protected InputStream certificate;
   protected String certificateContentType;
@@ -88,6 +91,7 @@ public class CreateDestinationOptions extends GenericModel {
     private String name;
     private String type;
     private String description;
+    private Boolean collectFailedEvents;
     private DestinationConfig config;
     private InputStream certificate;
     private String certificateContentType;
@@ -114,6 +118,7 @@ public class CreateDestinationOptions extends GenericModel {
       this.name = createDestinationOptions.name;
       this.type = createDestinationOptions.type;
       this.description = createDestinationOptions.description;
+      this.collectFailedEvents = createDestinationOptions.collectFailedEvents;
       this.config = createDestinationOptions.config;
       this.certificate = createDestinationOptions.certificate;
       this.certificateContentType = createDestinationOptions.certificateContentType;
@@ -200,6 +205,17 @@ public class CreateDestinationOptions extends GenericModel {
      */
     public Builder description(String description) {
       this.description = description;
+      return this;
+    }
+
+    /**
+     * Set the collectFailedEvents.
+     *
+     * @param collectFailedEvents the collectFailedEvents
+     * @return the CreateDestinationOptions builder
+     */
+    public Builder collectFailedEvents(Boolean collectFailedEvents) {
+      this.collectFailedEvents = collectFailedEvents;
       return this;
     }
 
@@ -473,6 +489,7 @@ public class CreateDestinationOptions extends GenericModel {
     name = builder.name;
     type = builder.type;
     description = builder.description;
+    collectFailedEvents = builder.collectFailedEvents;
     config = builder.config;
     certificate = builder.certificate;
     certificateContentType = builder.certificateContentType;
@@ -541,6 +558,17 @@ public class CreateDestinationOptions extends GenericModel {
    */
   public String description() {
     return description;
+  }
+
+  /**
+   * Gets the collectFailedEvents.
+   *
+   * Whether to collect the failed event in Cloud Object Storage bucket.
+   *
+   * @return the collectFailedEvents
+   */
+  public Boolean collectFailedEvents() {
+    return collectFailedEvents;
   }
 
   /**

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateIntegrationOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateIntegrationOptions.java
@@ -1,0 +1,171 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The createIntegration options.
+ */
+public class CreateIntegrationOptions extends GenericModel {
+
+  /**
+   * The type of Integration.
+   */
+  public interface Type {
+    /** collect_failed_events. */
+    String COLLECT_FAILED_EVENTS = "collect_failed_events";
+  }
+
+  protected String instanceId;
+  protected String type;
+  protected IntegrationCreateMetadata metadata;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String instanceId;
+    private String type;
+    private IntegrationCreateMetadata metadata;
+
+    /**
+     * Instantiates a new Builder from an existing CreateIntegrationOptions instance.
+     *
+     * @param createIntegrationOptions the instance to initialize the Builder with
+     */
+    private Builder(CreateIntegrationOptions createIntegrationOptions) {
+      this.instanceId = createIntegrationOptions.instanceId;
+      this.type = createIntegrationOptions.type;
+      this.metadata = createIntegrationOptions.metadata;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param instanceId the instanceId
+     * @param type the type
+     * @param metadata the metadata
+     */
+    public Builder(String instanceId, String type, IntegrationCreateMetadata metadata) {
+      this.instanceId = instanceId;
+      this.type = type;
+      this.metadata = metadata;
+    }
+
+    /**
+     * Builds a CreateIntegrationOptions.
+     *
+     * @return the new CreateIntegrationOptions instance
+     */
+    public CreateIntegrationOptions build() {
+      return new CreateIntegrationOptions(this);
+    }
+
+    /**
+     * Set the instanceId.
+     *
+     * @param instanceId the instanceId
+     * @return the CreateIntegrationOptions builder
+     */
+    public Builder instanceId(String instanceId) {
+      this.instanceId = instanceId;
+      return this;
+    }
+
+    /**
+     * Set the type.
+     *
+     * @param type the type
+     * @return the CreateIntegrationOptions builder
+     */
+    public Builder type(String type) {
+      this.type = type;
+      return this;
+    }
+
+    /**
+     * Set the metadata.
+     *
+     * @param metadata the metadata
+     * @return the CreateIntegrationOptions builder
+     */
+    public Builder metadata(IntegrationCreateMetadata metadata) {
+      this.metadata = metadata;
+      return this;
+    }
+  }
+
+  protected CreateIntegrationOptions() { }
+
+  protected CreateIntegrationOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.instanceId,
+      "instanceId cannot be empty");
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.type,
+      "type cannot be null");
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.metadata,
+      "metadata cannot be null");
+    instanceId = builder.instanceId;
+    type = builder.type;
+    metadata = builder.metadata;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a CreateIntegrationOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the instanceId.
+   *
+   * Unique identifier for IBM Cloud Event Notifications instance.
+   *
+   * @return the instanceId
+   */
+  public String instanceId() {
+    return instanceId;
+  }
+
+  /**
+   * Gets the type.
+   *
+   * The type of Integration.
+   *
+   * @return the type
+   */
+  public String type() {
+    return type;
+  }
+
+  /**
+   * Gets the metadata.
+   *
+   * Integration Metadata object.
+   *
+   * @return the metadata
+   */
+  public IntegrationCreateMetadata metadata() {
+    return metadata;
+  }
+}
+

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/Destination.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/Destination.java
@@ -58,12 +58,16 @@ public class Destination extends GenericModel {
     String PUSH_HUAWEI = "push_huawei";
     /** smtp_custom. */
     String SMTP_CUSTOM = "smtp_custom";
+    /** sms_custom. */
+    String SMS_CUSTOM = "sms_custom";
   }
 
   protected String id;
   protected String name;
   protected String description;
   protected String type;
+  @SerializedName("collect_failed_events")
+  protected Boolean collectFailedEvents;
   protected DestinationConfig config;
   @SerializedName("updated_at")
   protected Date updatedAt;
@@ -117,6 +121,17 @@ public class Destination extends GenericModel {
    */
   public String getType() {
     return type;
+  }
+
+  /**
+   * Gets the collectFailedEvents.
+   *
+   * Whether to collect the failed event in Cloud Object Storage bucket.
+   *
+   * @return the collectFailedEvents
+   */
+  public Boolean isCollectFailedEvents() {
+    return collectFailedEvents;
   }
 
   /**

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationListItem.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationListItem.java
@@ -57,12 +57,16 @@ public class DestinationListItem extends GenericModel {
     String PUSH_HUAWEI = "push_huawei";
     /** smtp_custom. */
     String SMTP_CUSTOM = "smtp_custom";
+    /** sms_custom. */
+    String SMS_CUSTOM = "sms_custom";
   }
 
   protected String id;
   protected String name;
   protected String description;
   protected String type;
+  @SerializedName("collect_failed_events")
+  protected Boolean collectFailedEvents;
   @SerializedName("subscription_count")
   protected Long subscriptionCount;
   @SerializedName("subscription_names")
@@ -114,6 +118,17 @@ public class DestinationListItem extends GenericModel {
    */
   public String getType() {
     return type;
+  }
+
+  /**
+   * Gets the collectFailedEvents.
+   *
+   * Whether to collect the failed event in Cloud Object Storage bucket.
+   *
+   * @return the collectFailedEvents
+   */
+  public Boolean isCollectFailedEvents() {
+    return collectFailedEvents;
   }
 
   /**

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationResponse.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationResponse.java
@@ -56,12 +56,16 @@ public class DestinationResponse extends GenericModel {
     String PUSH_HUAWEI = "push_huawei";
     /** smtp_custom. */
     String SMTP_CUSTOM = "smtp_custom";
+    /** sms_custom. */
+    String SMS_CUSTOM = "sms_custom";
   }
 
   protected String id;
   protected String name;
   protected String description;
   protected String type;
+  @SerializedName("collect_failed_events")
+  protected Boolean collectFailedEvents;
   protected DestinationConfig config;
   @SerializedName("created_at")
   protected Date createdAt;
@@ -110,6 +114,17 @@ public class DestinationResponse extends GenericModel {
    */
   public String getType() {
     return type;
+  }
+
+  /**
+   * Gets the collectFailedEvents.
+   *
+   * Whether to collect the failed event in Cloud Object Storage bucket.
+   *
+   * @return the collectFailedEvents
+   */
+  public Boolean isCollectFailedEvents() {
+    return collectFailedEvents;
   }
 
   /**

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/EnabledCountriesResponse.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/EnabledCountriesResponse.java
@@ -1,0 +1,53 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
+
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * Payload describing a custom SMS Configuration.
+ */
+public class EnabledCountriesResponse extends GenericModel {
+
+  protected String status;
+  @SerializedName("enabled_countries")
+  protected List<SMSCountryConfig> enabledCountries;
+
+  protected EnabledCountriesResponse() { }
+
+  /**
+   * Gets the status.
+   *
+   * The SMS destination status.
+   *
+   * @return the status
+   */
+  public String getStatus() {
+    return status;
+  }
+
+  /**
+   * Gets the enabledCountries.
+   *
+   * List enabled countries.
+   *
+   * @return the enabledCountries
+   */
+  public List<SMSCountryConfig> getEnabledCountries() {
+    return enabledCountries;
+  }
+}
+

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetEnabledCountriesOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetEnabledCountriesOptions.java
@@ -1,0 +1,133 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The getEnabledCountries options.
+ */
+public class GetEnabledCountriesOptions extends GenericModel {
+
+  protected String instanceId;
+  protected String id;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String instanceId;
+    private String id;
+
+    /**
+     * Instantiates a new Builder from an existing GetEnabledCountriesOptions instance.
+     *
+     * @param getEnabledCountriesOptions the instance to initialize the Builder with
+     */
+    private Builder(GetEnabledCountriesOptions getEnabledCountriesOptions) {
+      this.instanceId = getEnabledCountriesOptions.instanceId;
+      this.id = getEnabledCountriesOptions.id;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param instanceId the instanceId
+     * @param id the id
+     */
+    public Builder(String instanceId, String id) {
+      this.instanceId = instanceId;
+      this.id = id;
+    }
+
+    /**
+     * Builds a GetEnabledCountriesOptions.
+     *
+     * @return the new GetEnabledCountriesOptions instance
+     */
+    public GetEnabledCountriesOptions build() {
+      return new GetEnabledCountriesOptions(this);
+    }
+
+    /**
+     * Set the instanceId.
+     *
+     * @param instanceId the instanceId
+     * @return the GetEnabledCountriesOptions builder
+     */
+    public Builder instanceId(String instanceId) {
+      this.instanceId = instanceId;
+      return this;
+    }
+
+    /**
+     * Set the id.
+     *
+     * @param id the id
+     * @return the GetEnabledCountriesOptions builder
+     */
+    public Builder id(String id) {
+      this.id = id;
+      return this;
+    }
+  }
+
+  protected GetEnabledCountriesOptions() { }
+
+  protected GetEnabledCountriesOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.instanceId,
+      "instanceId cannot be empty");
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.id,
+      "id cannot be empty");
+    instanceId = builder.instanceId;
+    id = builder.id;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a GetEnabledCountriesOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the instanceId.
+   *
+   * Unique identifier for IBM Cloud Event Notifications instance.
+   *
+   * @return the instanceId
+   */
+  public String instanceId() {
+    return instanceId;
+  }
+
+  /**
+   * Gets the id.
+   *
+   * Unique identifier for Destination.
+   *
+   * @return the id
+   */
+  public String id() {
+    return id;
+  }
+}
+

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/IntegrationCreateMetadata.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/IntegrationCreateMetadata.java
@@ -18,12 +18,10 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
 /**
  * Integration Metadata object.
  */
-public class IntegrationMetadata extends GenericModel {
+public class IntegrationCreateMetadata extends GenericModel {
 
   protected String endpoint;
   protected String crn;
-  @SerializedName("root_key_id")
-  protected String rootKeyId;
   @SerializedName("bucket_name")
   protected String bucketName;
 
@@ -33,19 +31,17 @@ public class IntegrationMetadata extends GenericModel {
   public static class Builder {
     private String endpoint;
     private String crn;
-    private String rootKeyId;
     private String bucketName;
 
     /**
-     * Instantiates a new Builder from an existing IntegrationMetadata instance.
+     * Instantiates a new Builder from an existing IntegrationCreateMetadata instance.
      *
-     * @param integrationMetadata the instance to initialize the Builder with
+     * @param integrationCreateMetadata the instance to initialize the Builder with
      */
-    private Builder(IntegrationMetadata integrationMetadata) {
-      this.endpoint = integrationMetadata.endpoint;
-      this.crn = integrationMetadata.crn;
-      this.rootKeyId = integrationMetadata.rootKeyId;
-      this.bucketName = integrationMetadata.bucketName;
+    private Builder(IntegrationCreateMetadata integrationCreateMetadata) {
+      this.endpoint = integrationCreateMetadata.endpoint;
+      this.crn = integrationCreateMetadata.crn;
+      this.bucketName = integrationCreateMetadata.bucketName;
     }
 
     /**
@@ -59,26 +55,28 @@ public class IntegrationMetadata extends GenericModel {
      *
      * @param endpoint the endpoint
      * @param crn the crn
+     * @param bucketName the bucketName
      */
-    public Builder(String endpoint, String crn) {
+    public Builder(String endpoint, String crn, String bucketName) {
       this.endpoint = endpoint;
       this.crn = crn;
+      this.bucketName = bucketName;
     }
 
     /**
-     * Builds a IntegrationMetadata.
+     * Builds a IntegrationCreateMetadata.
      *
-     * @return the new IntegrationMetadata instance
+     * @return the new IntegrationCreateMetadata instance
      */
-    public IntegrationMetadata build() {
-      return new IntegrationMetadata(this);
+    public IntegrationCreateMetadata build() {
+      return new IntegrationCreateMetadata(this);
     }
 
     /**
      * Set the endpoint.
      *
      * @param endpoint the endpoint
-     * @return the IntegrationMetadata builder
+     * @return the IntegrationCreateMetadata builder
      */
     public Builder endpoint(String endpoint) {
       this.endpoint = endpoint;
@@ -89,7 +87,7 @@ public class IntegrationMetadata extends GenericModel {
      * Set the crn.
      *
      * @param crn the crn
-     * @return the IntegrationMetadata builder
+     * @return the IntegrationCreateMetadata builder
      */
     public Builder crn(String crn) {
       this.crn = crn;
@@ -97,21 +95,10 @@ public class IntegrationMetadata extends GenericModel {
     }
 
     /**
-     * Set the rootKeyId.
-     *
-     * @param rootKeyId the rootKeyId
-     * @return the IntegrationMetadata builder
-     */
-    public Builder rootKeyId(String rootKeyId) {
-      this.rootKeyId = rootKeyId;
-      return this;
-    }
-
-    /**
      * Set the bucketName.
      *
      * @param bucketName the bucketName
-     * @return the IntegrationMetadata builder
+     * @return the IntegrationCreateMetadata builder
      */
     public Builder bucketName(String bucketName) {
       this.bucketName = bucketName;
@@ -119,23 +106,24 @@ public class IntegrationMetadata extends GenericModel {
     }
   }
 
-  protected IntegrationMetadata() { }
+  protected IntegrationCreateMetadata() { }
 
-  protected IntegrationMetadata(Builder builder) {
+  protected IntegrationCreateMetadata(Builder builder) {
     com.ibm.cloud.sdk.core.util.Validator.notNull(builder.endpoint,
       "endpoint cannot be null");
     com.ibm.cloud.sdk.core.util.Validator.notNull(builder.crn,
       "crn cannot be null");
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.bucketName,
+      "bucketName cannot be null");
     endpoint = builder.endpoint;
     crn = builder.crn;
-    rootKeyId = builder.rootKeyId;
     bucketName = builder.bucketName;
   }
 
   /**
    * New builder.
    *
-   * @return a IntegrationMetadata builder
+   * @return a IntegrationCreateMetadata builder
    */
   public Builder newBuilder() {
     return new Builder(this);
@@ -144,7 +132,7 @@ public class IntegrationMetadata extends GenericModel {
   /**
    * Gets the endpoint.
    *
-   * KMS url for key management or url for COS bucket.
+   * URL for Cloud Object storage.
    *
    * @return the endpoint
    */
@@ -155,7 +143,7 @@ public class IntegrationMetadata extends GenericModel {
   /**
    * Gets the crn.
    *
-   * CRN of the KMS/COS instance.
+   * CRN of the Cloud Object Storage instance.
    *
    * @return the crn
    */
@@ -164,20 +152,9 @@ public class IntegrationMetadata extends GenericModel {
   }
 
   /**
-   * Gets the rootKeyId.
-   *
-   * Root Key ID of KMS.
-   *
-   * @return the rootKeyId
-   */
-  public String rootKeyId() {
-    return rootKeyId;
-  }
-
-  /**
    * Gets the bucketName.
    *
-   * cloud object storage bucket name.
+   * Cloud Object Storage bucket name.
    *
    * @return the bucketName
    */

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/IntegrationCreateResponse.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/IntegrationCreateResponse.java
@@ -1,0 +1,77 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
+
+import java.util.Date;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * Integration create response object.
+ */
+public class IntegrationCreateResponse extends GenericModel {
+
+  protected String id;
+  protected String type;
+  protected IntegrationCreateMetadata metadata;
+  @SerializedName("created_at")
+  protected Date createdAt;
+
+  protected IntegrationCreateResponse() { }
+
+  /**
+   * Gets the id.
+   *
+   * ID of the integration.
+   *
+   * @return the id
+   */
+  public String getId() {
+    return id;
+  }
+
+  /**
+   * Gets the type.
+   *
+   * Integration type. Allowed values collect_failed_events.
+   *
+   * @return the type
+   */
+  public String getType() {
+    return type;
+  }
+
+  /**
+   * Gets the metadata.
+   *
+   * Integration Metadata object.
+   *
+   * @return the metadata
+   */
+  public IntegrationCreateMetadata getMetadata() {
+    return metadata;
+  }
+
+  /**
+   * Gets the createdAt.
+   *
+   * Creation time of an integration.
+   *
+   * @return the createdAt
+   */
+  public Date getCreatedAt() {
+    return createdAt;
+  }
+}
+

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/NotificationCreate.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/NotificationCreate.java
@@ -45,6 +45,8 @@ public class NotificationCreate extends DynamicModel<Object> {
   protected String ibmendefaultlong;
   @SerializedName("ibmensubject")
   protected String ibmensubject;
+  @SerializedName("ibmensmsto")
+  protected String ibmensmsto;
   @SerializedName("ibmenmailto")
   protected String ibmenmailto;
   @SerializedName("ibmenhtmlbody")
@@ -94,6 +96,7 @@ public class NotificationCreate extends DynamicModel<Object> {
     private String ibmendefaultshort;
     private String ibmendefaultlong;
     private String ibmensubject;
+    private String ibmensmsto;
     private String ibmenmailto;
     private String ibmenhtmlbody;
     private String subject;
@@ -127,6 +130,7 @@ public class NotificationCreate extends DynamicModel<Object> {
       this.ibmendefaultshort = notificationCreate.ibmendefaultshort;
       this.ibmendefaultlong = notificationCreate.ibmendefaultlong;
       this.ibmensubject = notificationCreate.ibmensubject;
+      this.ibmensmsto = notificationCreate.ibmensmsto;
       this.ibmenmailto = notificationCreate.ibmenmailto;
       this.ibmenhtmlbody = notificationCreate.ibmenhtmlbody;
       this.subject = notificationCreate.subject;
@@ -288,6 +292,17 @@ public class NotificationCreate extends DynamicModel<Object> {
      */
     public Builder ibmensubject(String ibmensubject) {
       this.ibmensubject = ibmensubject;
+      return this;
+    }
+
+    /**
+     * Set the ibmensmsto.
+     *
+     * @param ibmensmsto the ibmensmsto
+     * @return the NotificationCreate builder
+     */
+    public Builder ibmensmsto(String ibmensmsto) {
+      this.ibmensmsto = ibmensmsto;
       return this;
     }
 
@@ -499,6 +514,7 @@ public class NotificationCreate extends DynamicModel<Object> {
     ibmendefaultshort = builder.ibmendefaultshort;
     ibmendefaultlong = builder.ibmendefaultlong;
     ibmensubject = builder.ibmensubject;
+    ibmensmsto = builder.ibmensmsto;
     ibmenmailto = builder.ibmenmailto;
     ibmenhtmlbody = builder.ibmenhtmlbody;
     subject = builder.subject;
@@ -724,6 +740,26 @@ public class NotificationCreate extends DynamicModel<Object> {
    */
   public void setIbmensubject(final String ibmensubject) {
     this.ibmensubject = ibmensubject;
+  }
+
+  /**
+   * Gets the ibmensmsto.
+   *
+   * The SMS number string.
+   *
+   * @return the ibmensmsto
+   */
+  public String getIbmensmsto() {
+    return this.ibmensmsto;
+  }
+
+  /**
+   * Sets the ibmensmsto.
+   *
+   * @param ibmensmsto the new ibmensmsto
+   */
+  public void setIbmensmsto(final String ibmensmsto) {
+    this.ibmensmsto = ibmensmsto;
   }
 
   /**

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ReplaceTemplateOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ReplaceTemplateOptions.java
@@ -15,9 +15,9 @@ package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
 import com.ibm.cloud.sdk.core.service.model.GenericModel;
 
 /**
- * The updateTemplate options.
+ * The replaceTemplate options.
  */
-public class UpdateTemplateOptions extends GenericModel {
+public class ReplaceTemplateOptions extends GenericModel {
 
   protected String instanceId;
   protected String id;
@@ -38,17 +38,17 @@ public class UpdateTemplateOptions extends GenericModel {
     private TemplateConfig params;
 
     /**
-     * Instantiates a new Builder from an existing UpdateTemplateOptions instance.
+     * Instantiates a new Builder from an existing ReplaceTemplateOptions instance.
      *
-     * @param updateTemplateOptions the instance to initialize the Builder with
+     * @param replaceTemplateOptions the instance to initialize the Builder with
      */
-    private Builder(UpdateTemplateOptions updateTemplateOptions) {
-      this.instanceId = updateTemplateOptions.instanceId;
-      this.id = updateTemplateOptions.id;
-      this.name = updateTemplateOptions.name;
-      this.description = updateTemplateOptions.description;
-      this.type = updateTemplateOptions.type;
-      this.params = updateTemplateOptions.params;
+    private Builder(ReplaceTemplateOptions replaceTemplateOptions) {
+      this.instanceId = replaceTemplateOptions.instanceId;
+      this.id = replaceTemplateOptions.id;
+      this.name = replaceTemplateOptions.name;
+      this.description = replaceTemplateOptions.description;
+      this.type = replaceTemplateOptions.type;
+      this.params = replaceTemplateOptions.params;
     }
 
     /**
@@ -69,19 +69,19 @@ public class UpdateTemplateOptions extends GenericModel {
     }
 
     /**
-     * Builds a UpdateTemplateOptions.
+     * Builds a ReplaceTemplateOptions.
      *
-     * @return the new UpdateTemplateOptions instance
+     * @return the new ReplaceTemplateOptions instance
      */
-    public UpdateTemplateOptions build() {
-      return new UpdateTemplateOptions(this);
+    public ReplaceTemplateOptions build() {
+      return new ReplaceTemplateOptions(this);
     }
 
     /**
      * Set the instanceId.
      *
      * @param instanceId the instanceId
-     * @return the UpdateTemplateOptions builder
+     * @return the ReplaceTemplateOptions builder
      */
     public Builder instanceId(String instanceId) {
       this.instanceId = instanceId;
@@ -92,7 +92,7 @@ public class UpdateTemplateOptions extends GenericModel {
      * Set the id.
      *
      * @param id the id
-     * @return the UpdateTemplateOptions builder
+     * @return the ReplaceTemplateOptions builder
      */
     public Builder id(String id) {
       this.id = id;
@@ -103,7 +103,7 @@ public class UpdateTemplateOptions extends GenericModel {
      * Set the name.
      *
      * @param name the name
-     * @return the UpdateTemplateOptions builder
+     * @return the ReplaceTemplateOptions builder
      */
     public Builder name(String name) {
       this.name = name;
@@ -114,7 +114,7 @@ public class UpdateTemplateOptions extends GenericModel {
      * Set the description.
      *
      * @param description the description
-     * @return the UpdateTemplateOptions builder
+     * @return the ReplaceTemplateOptions builder
      */
     public Builder description(String description) {
       this.description = description;
@@ -125,7 +125,7 @@ public class UpdateTemplateOptions extends GenericModel {
      * Set the type.
      *
      * @param type the type
-     * @return the UpdateTemplateOptions builder
+     * @return the ReplaceTemplateOptions builder
      */
     public Builder type(String type) {
       this.type = type;
@@ -136,7 +136,7 @@ public class UpdateTemplateOptions extends GenericModel {
      * Set the params.
      *
      * @param params the params
-     * @return the UpdateTemplateOptions builder
+     * @return the ReplaceTemplateOptions builder
      */
     public Builder params(TemplateConfig params) {
       this.params = params;
@@ -144,9 +144,9 @@ public class UpdateTemplateOptions extends GenericModel {
     }
   }
 
-  protected UpdateTemplateOptions() { }
+  protected ReplaceTemplateOptions() { }
 
-  protected UpdateTemplateOptions(Builder builder) {
+  protected ReplaceTemplateOptions(Builder builder) {
     com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.instanceId,
       "instanceId cannot be empty");
     com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.id,
@@ -162,7 +162,7 @@ public class UpdateTemplateOptions extends GenericModel {
   /**
    * New builder.
    *
-   * @return a UpdateTemplateOptions builder
+   * @return a ReplaceTemplateOptions builder
    */
   public Builder newBuilder() {
     return new Builder(this);

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SMSCountryConfig.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SMSCountryConfig.java
@@ -1,0 +1,51 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
+
+import java.util.List;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * Payload describing a country Configuration.
+ */
+public class SMSCountryConfig extends GenericModel {
+
+  protected String number;
+  protected List<String> country;
+
+  protected SMSCountryConfig() { }
+
+  /**
+   * Gets the number.
+   *
+   * Phone number.
+   *
+   * @return the number
+   */
+  public String getNumber() {
+    return number;
+  }
+
+  /**
+   * Gets the country.
+   *
+   * List of Countries.
+   *
+   * @return the country
+   */
+  public List<String> getCountry() {
+    return country;
+  }
+}
+

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/Subscription.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/Subscription.java
@@ -59,6 +59,8 @@ public class Subscription extends DynamicModel<Object> {
     String PUSH_HUAWEI = "push_huawei";
     /** smtp_custom. */
     String SMTP_CUSTOM = "smtp_custom";
+    /** sms_custom. */
+    String SMS_CUSTOM = "sms_custom";
   }
 
   @SerializedName("id")

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionAttributes.java
@@ -23,6 +23,7 @@ import com.ibm.cloud.sdk.core.service.model.DynamicModel;
  *
  * Classes which extend this class:
  * - SubscriptionAttributesSMSAttributesResponse
+ * - SubscriptionAttributesCustomSMSAttributesResponse
  * - SubscriptionAttributesEmailAttributesResponse
  * - SubscriptionAttributesCustomEmailAttributesResponse
  * - SubscriptionAttributesWebhookAttributesResponse
@@ -89,7 +90,7 @@ public class SubscriptionAttributes extends DynamicModel<Object> {
   /**
    * Gets the invited.
    *
-   * The email id string.
+   * The SMS numder string.
    *
    * @return the invited
    */

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionAttributesCustomSMSAttributesResponse.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionAttributesCustomSMSAttributesResponse.java
@@ -1,0 +1,24 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
+
+/**
+ * Custom SMS attributes object.
+ */
+public class SubscriptionAttributesCustomSMSAttributesResponse extends SubscriptionAttributes {
+
+
+  public SubscriptionAttributesCustomSMSAttributesResponse() {
+    super();
+  }
+}

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributes.java
@@ -23,6 +23,7 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
  * Classes which extend this class:
  * - SubscriptionCreateAttributesSMSAttributes
  * - SubscriptionCreateAttributesEmailAttributes
+ * - SubscriptionCreateAttributesCustomSMSAttributes
  * - SubscriptionCreateAttributesCustomEmailAttributes
  * - SubscriptionCreateAttributesWebhookAttributes
  * - SubscriptionCreateAttributesFCMAttributes

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesCustomSMSAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesCustomSMSAttributes.java
@@ -1,0 +1,109 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The attributes for an custom sms notification.
+ */
+public class SubscriptionCreateAttributesCustomSMSAttributes extends SubscriptionCreateAttributes {
+
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private List<String> invited;
+
+    /**
+     * Instantiates a new Builder from an existing SubscriptionCreateAttributesCustomSMSAttributes instance.
+     *
+     * @param subscriptionCreateAttributesCustomSmsAttributes the instance to initialize the Builder with
+     */
+    public Builder(SubscriptionCreateAttributes subscriptionCreateAttributesCustomSmsAttributes) {
+      this.invited = subscriptionCreateAttributesCustomSmsAttributes.invited;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param invited the invited
+     */
+    public Builder(List<String> invited) {
+      this.invited = invited;
+    }
+
+    /**
+     * Builds a SubscriptionCreateAttributesCustomSMSAttributes.
+     *
+     * @return the new SubscriptionCreateAttributesCustomSMSAttributes instance
+     */
+    public SubscriptionCreateAttributesCustomSMSAttributes build() {
+      return new SubscriptionCreateAttributesCustomSMSAttributes(this);
+    }
+
+    /**
+     * Adds an invited to invited.
+     *
+     * @param invited the new invited
+     * @return the SubscriptionCreateAttributesCustomSMSAttributes builder
+     */
+    public Builder addInvited(String invited) {
+      com.ibm.cloud.sdk.core.util.Validator.notNull(invited,
+        "invited cannot be null");
+      if (this.invited == null) {
+        this.invited = new ArrayList<String>();
+      }
+      this.invited.add(invited);
+      return this;
+    }
+
+    /**
+     * Set the invited.
+     * Existing invited will be replaced.
+     *
+     * @param invited the invited
+     * @return the SubscriptionCreateAttributesCustomSMSAttributes builder
+     */
+    public Builder invited(List<String> invited) {
+      this.invited = invited;
+      return this;
+    }
+  }
+
+  protected SubscriptionCreateAttributesCustomSMSAttributes() { }
+
+  protected SubscriptionCreateAttributesCustomSMSAttributes(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.invited,
+      "invited cannot be null");
+    invited = builder.invited;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a SubscriptionCreateAttributesCustomSMSAttributes builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+}
+

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionListItem.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionListItem.java
@@ -60,6 +60,8 @@ public class SubscriptionListItem extends GenericModel {
     String PUSH_HUAWEI = "push_huawei";
     /** smtp_custom. */
     String SMTP_CUSTOM = "smtp_custom";
+    /** sms_custom. */
+    String SMS_CUSTOM = "sms_custom";
   }
 
   protected String id;

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributes.java
@@ -21,6 +21,7 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
  * Classes which extend this class:
  * - SubscriptionUpdateAttributesSMSUpdateAttributes
  * - SubscriptionUpdateAttributesEmailUpdateAttributes
+ * - SubscriptionUpdateAttributesCustomSMSUpdateAttributes
  * - SubscriptionUpdateAttributesCustomEmailUpdateAttributes
  * - SubscriptionUpdateAttributesWebhookAttributes
  * - SubscriptionUpdateAttributesSlackAttributes

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributesCustomSMSUpdateAttributes.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributesCustomSMSUpdateAttributes.java
@@ -1,0 +1,106 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
+
+/**
+ * SMS attributes object.
+ */
+public class SubscriptionUpdateAttributesCustomSMSUpdateAttributes extends SubscriptionUpdateAttributes {
+
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private UpdateAttributesInvited invited;
+    private UpdateAttributesSubscribed subscribed;
+    private UpdateAttributesUnsubscribed unsubscribed;
+
+    /**
+     * Instantiates a new Builder from an existing SubscriptionUpdateAttributesCustomSMSUpdateAttributes instance.
+     *
+     * @param subscriptionUpdateAttributesCustomSmsUpdateAttributes the instance to initialize the Builder with
+     */
+    public Builder(SubscriptionUpdateAttributes subscriptionUpdateAttributesCustomSmsUpdateAttributes) {
+      this.invited = subscriptionUpdateAttributesCustomSmsUpdateAttributes.invited;
+      this.subscribed = subscriptionUpdateAttributesCustomSmsUpdateAttributes.subscribed;
+      this.unsubscribed = subscriptionUpdateAttributesCustomSmsUpdateAttributes.unsubscribed;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Builds a SubscriptionUpdateAttributesCustomSMSUpdateAttributes.
+     *
+     * @return the new SubscriptionUpdateAttributesCustomSMSUpdateAttributes instance
+     */
+    public SubscriptionUpdateAttributesCustomSMSUpdateAttributes build() {
+      return new SubscriptionUpdateAttributesCustomSMSUpdateAttributes(this);
+    }
+
+    /**
+     * Set the invited.
+     *
+     * @param invited the invited
+     * @return the SubscriptionUpdateAttributesCustomSMSUpdateAttributes builder
+     */
+    public Builder invited(UpdateAttributesInvited invited) {
+      this.invited = invited;
+      return this;
+    }
+
+    /**
+     * Set the subscribed.
+     *
+     * @param subscribed the subscribed
+     * @return the SubscriptionUpdateAttributesCustomSMSUpdateAttributes builder
+     */
+    public Builder subscribed(UpdateAttributesSubscribed subscribed) {
+      this.subscribed = subscribed;
+      return this;
+    }
+
+    /**
+     * Set the unsubscribed.
+     *
+     * @param unsubscribed the unsubscribed
+     * @return the SubscriptionUpdateAttributesCustomSMSUpdateAttributes builder
+     */
+    public Builder unsubscribed(UpdateAttributesUnsubscribed unsubscribed) {
+      this.unsubscribed = unsubscribed;
+      return this;
+    }
+  }
+
+  protected SubscriptionUpdateAttributesCustomSMSUpdateAttributes() { }
+
+  protected SubscriptionUpdateAttributesCustomSMSUpdateAttributes(Builder builder) {
+    invited = builder.invited;
+    subscribed = builder.subscribed;
+    unsubscribed = builder.unsubscribed;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a SubscriptionUpdateAttributesCustomSMSUpdateAttributes builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+}
+

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/UpdateDestinationOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/UpdateDestinationOptions.java
@@ -28,6 +28,7 @@ public class UpdateDestinationOptions extends GenericModel {
   protected String id;
   protected String name;
   protected String description;
+  protected Boolean collectFailedEvents;
   protected DestinationConfig config;
   protected InputStream certificate;
   protected String certificateContentType;
@@ -52,6 +53,7 @@ public class UpdateDestinationOptions extends GenericModel {
     private String id;
     private String name;
     private String description;
+    private Boolean collectFailedEvents;
     private DestinationConfig config;
     private InputStream certificate;
     private String certificateContentType;
@@ -78,6 +80,7 @@ public class UpdateDestinationOptions extends GenericModel {
       this.id = updateDestinationOptions.id;
       this.name = updateDestinationOptions.name;
       this.description = updateDestinationOptions.description;
+      this.collectFailedEvents = updateDestinationOptions.collectFailedEvents;
       this.config = updateDestinationOptions.config;
       this.certificate = updateDestinationOptions.certificate;
       this.certificateContentType = updateDestinationOptions.certificateContentType;
@@ -162,6 +165,17 @@ public class UpdateDestinationOptions extends GenericModel {
      */
     public Builder description(String description) {
       this.description = description;
+      return this;
+    }
+
+    /**
+     * Set the collectFailedEvents.
+     *
+     * @param collectFailedEvents the collectFailedEvents
+     * @return the UpdateDestinationOptions builder
+     */
+    public Builder collectFailedEvents(Boolean collectFailedEvents) {
+      this.collectFailedEvents = collectFailedEvents;
       return this;
     }
 
@@ -433,6 +447,7 @@ public class UpdateDestinationOptions extends GenericModel {
     id = builder.id;
     name = builder.name;
     description = builder.description;
+    collectFailedEvents = builder.collectFailedEvents;
     config = builder.config;
     certificate = builder.certificate;
     certificateContentType = builder.certificateContentType;
@@ -501,6 +516,17 @@ public class UpdateDestinationOptions extends GenericModel {
    */
   public String description() {
     return description;
+  }
+
+  /**
+   * Gets the collectFailedEvents.
+   *
+   * Whether to collect the failed event in Cloud Object Storage bucket.
+   *
+   * @return the collectFailedEvents
+   */
+  public Boolean collectFailedEvents() {
+    return collectFailedEvents;
   }
 
   /**

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsIT.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsIT.java
@@ -65,6 +65,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   public static String destinationId14 = "";
   public static String destinationId15 = "";
   public static String destinationId16 = "";
+  public static String destinationId17 = "";
   public static String subscriptionId = "";
   public static String subscriptionId1 = "";
   public static String subscriptionId2 = "";
@@ -82,6 +83,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   public static String subscriptionId14 = "";
   public static String subscriptionId15 = "";
   public static String subscriptionId16 = "";
+  public static String subscriptionId17 = "";
   public static String fcmServerKey = "";
   public static String fcmSenderId = "";
   public static String integrationId = "";
@@ -105,6 +107,10 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   public static String teamsURL = "";
   public static String pagerDutyApiKey = "";
   public static String pagerDutyRoutingKey = "";
+  public static String templateBody = "";
+  public static String cosInstanceCRN = "";
+  public static String cosIntegrationID = "";
+
 
 
 
@@ -150,10 +156,12 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
     cosBucketName = config.get("COS_BUCKET_NAME");
     cosEndPoint = config.get("COS_ENDPOINT");
     cosInstanceID = config.get("COS_INSTANCE");
+    cosInstanceCRN = config.get("COS_INSTANCE_CRN");
     slackURL = config.get("SLACK_URL");
     teamsURL = config.get("MS_TEAMS_URL");
     pagerDutyApiKey = config.get("PD_API_KEY");
     pagerDutyRoutingKey = config.get("PD_ROUTING_KEY");
+    templateBody = config.get("TEMPLATE_BODY");
 
     service.enableRetries(4, 30);
 
@@ -1119,6 +1127,25 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
 
       destinationId16 = destinationCustomResponseResult.getId();
 
+      String customSMSName = "Custom SMS";
+      String customSMSTypeVal = "sms_custom";
+      String customSMSDescription = "Custom SMS Destination";
+
+      CreateDestinationOptions createCustomSMSDestinationOptions = new CreateDestinationOptions.Builder()
+              .instanceId(instanceId)
+              .name(customSMSName)
+              .type(customSMSTypeVal)
+              .collectFailedEvents(false)
+              .description(customSMSDescription)
+              .build();
+
+      Response<DestinationResponse> customSMSResponse = service.createDestination(createCustomSMSDestinationOptions).execute();
+      // Validate response
+      assertNotNull(customSMSResponse);
+      assertEquals(customSMSResponse.getStatusCode(), 201);
+
+      DestinationResponse destinationCustomSMSResponseResult = customSMSResponse.getResult();
+      destinationId17 = destinationCustomSMSResponseResult.getId();
 
       //
       // The following status codes aren't covered by tests.
@@ -1778,6 +1805,29 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
       VerificationResponse dkimResponseObj = dkimVerificationResponse.getResult();
       assertNotNull(dkimResponseObj);
 
+      String customSMSName = "Custom SMS update";
+      String customSMSDescription = "Custom SMS Destination update";
+
+      UpdateDestinationOptions updateCustomSMSDestinationOptions = new UpdateDestinationOptions.Builder()
+              .instanceId(instanceId)
+              .name(customSMSName)
+              .id(destinationId17)
+              .collectFailedEvents(false)
+              .description(customSMSDescription)
+              .build();
+
+      Response<Destination> customSMSResponse = service.updateDestination(updateCustomSMSDestinationOptions).execute();
+      // Validate response
+      assertNotNull(customSMSResponse);
+      assertEquals(customSMSResponse.getStatusCode(), 200);
+
+      Destination destinationCustomSMSResponseResult = customSMSResponse.getResult();
+
+      assertNotNull(destinationCustomSMSResponseResult);
+
+      assertEquals(destinationCustomSMSResponseResult.getId(), destinationId17);
+      assertEquals(destinationCustomSMSResponseResult.getDescription(), customSMSDescription);
+      assertEquals(destinationCustomSMSResponseResult.getName(), customSMSName);
 
       //
       // The following status codes aren't covered by tests.
@@ -1805,7 +1855,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
       String description = "template description";
 
       TemplateConfig templateConfig = new TemplateConfig.Builder()
-              .body("<!DOCTYPE html><html><head><title>IBM Event Notifications</title></head><body><p>Hello! Invitation template</p><table><tr><td>Hello invitation link:{{ ibmen_invitation }} </td></tr></table></body></html>")
+              .body(templateBody)
               .subject("Hi this is invitation for invitation message")
               .build();
 
@@ -1883,11 +1933,11 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
       String description = "template description";
 
       TemplateConfig templateConfig = new TemplateConfig.Builder()
-              .body("<!DOCTYPE html><html><head><title>IBM Event Notifications</title></head><body><p>Hello! Invitation template</p><table><tr><td>Hello invitation link:{{ ibmen_invitation }} </td></tr></table></body></html>")
+              .body(templateBody)
               .subject("Hi this is invitation for invitation message")
               .build();
 
-      UpdateTemplateOptions updateTemplateInvitationOptions = new UpdateTemplateOptions.Builder()
+      ReplaceTemplateOptions updateTemplateInvitationOptions = new ReplaceTemplateOptions.Builder()
               .instanceId(instanceId)
               .id(templateInvitationID)
               .name(name)
@@ -1896,7 +1946,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
               .params(templateConfig)
               .build();
 
-      Response<Template> invitationResponse = service.updateTemplate(updateTemplateInvitationOptions).execute();
+      Response<Template> invitationResponse = service.replaceTemplate(updateTemplateInvitationOptions).execute();
       assertNotNull(invitationResponse);
       assertEquals(invitationResponse.getStatusCode(), 200);
       Template invitationTemplateResult = invitationResponse.getResult();
@@ -1906,7 +1956,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
       assertEquals(invitationTemplateResult.getName(), name);
       assertEquals(invitationTemplateResult.getId(), templateInvitationID);
 
-      UpdateTemplateOptions updateTemplateNotificationOptions = new UpdateTemplateOptions.Builder()
+      ReplaceTemplateOptions updateTemplateNotificationOptions = new ReplaceTemplateOptions.Builder()
               .instanceId(instanceId)
               .id(templateNotificationID)
               .name(name)
@@ -1915,7 +1965,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
               .params(templateConfig)
               .build();
 
-      Response<Template> notificationResponse = service.updateTemplate(updateTemplateNotificationOptions).execute();
+      Response<Template> notificationResponse = service.replaceTemplate(updateTemplateNotificationOptions).execute();
       assertNotNull(notificationResponse);
       assertEquals(notificationResponse.getStatusCode(), 200);
       Template notificationTemplateResult = notificationResponse.getResult();
@@ -2400,6 +2450,36 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
       assertEquals(customSubscriptionResult.getName(), customName);
 
       subscriptionId16 = customSubscriptionResult.getId();
+
+      ArrayList<String> customToNumber = new ArrayList<String>();
+      customToNumber.add("+911234567890");
+      customToNumber.add("+122670546254");
+      SubscriptionCreateAttributesCustomSMSAttributes subscriptionCreateCustomSMSAttributesModel = new SubscriptionCreateAttributesCustomSMSAttributes.Builder()
+              .invited(customToNumber)
+              .build();
+
+      String customSMSName = "subscription_custom_sms";
+      String customSMSDescription = "Subscription custom sms";
+
+      CreateSubscriptionOptions createCustomSMSSubscriptionOptions = new CreateSubscriptionOptions.Builder()
+              .instanceId(instanceId)
+              .name(customSMSName)
+              .destinationId(destinationId17)
+              .topicId(topicId)
+              .attributes(subscriptionCreateCustomSMSAttributesModel)
+              .description(customSMSDescription)
+              .build();
+
+      Response<Subscription> customSMSResponse = service.createSubscription(createCustomSMSSubscriptionOptions).execute();
+      // Validate response
+      assertNotNull(customSMSResponse);
+      assertEquals(customSMSResponse.getStatusCode(), 201);
+      Subscription customSMSSubscriptionResult = customSMSResponse.getResult();
+      assertNotNull(customSMSSubscriptionResult);
+      assertEquals(customSMSSubscriptionResult.getDescription(), customSMSDescription);
+      assertEquals(customSMSSubscriptionResult.getName(), customSMSName);
+
+      subscriptionId17 = customSMSSubscriptionResult.getId();
 
       //
       // The following status codes aren't covered by tests.
@@ -2970,6 +3050,53 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
       assertNotNull(customEmailSubscriptionResult);
       assertEquals(customEmailSubscriptionResult.getDescription(), customEmailDescription);
       assertEquals(customEmailSubscriptionResult.getName(), customEmailName);
+
+      ArrayList<String> toCustomPhRemove = new ArrayList<String>();
+      toCustomPhRemove.add("+12064512559");
+
+      ArrayList<String> toCustomPhInvite = new ArrayList<String>();
+      toCustomPhInvite.add("+12064512559");
+
+      UpdateAttributesSubscribed customPhSubscribed = new UpdateAttributesSubscribed.Builder()
+              .remove(toCustomPhRemove)
+              .build();
+
+      UpdateAttributesUnsubscribed customPhUnSubscribed = new UpdateAttributesUnsubscribed.Builder()
+              .remove(toCustomPhRemove)
+              .build();
+
+      UpdateAttributesInvited customPhInvited = new UpdateAttributesInvited.Builder()
+              .add(toCustomPhInvite)
+              .build();
+
+      SubscriptionUpdateAttributesCustomSMSUpdateAttributes subscriptionUpdateCustomSMSAttributesModel = new SubscriptionUpdateAttributesCustomSMSUpdateAttributes.Builder()
+              .invited(customPhInvited)
+              .subscribed(customPhSubscribed)
+              .unsubscribed(customPhUnSubscribed)
+              .build();
+
+      String customSMSName = "custom sms subscription update";
+      String customSMSDescription = "custom subscription_update for sms";
+
+      UpdateSubscriptionOptions customSMSUpdateSubscriptionOptions = new UpdateSubscriptionOptions.Builder()
+              .instanceId(instanceId)
+              .name(customSMSName)
+              .id(subscriptionId17)
+              .attributes(subscriptionUpdateCustomSMSAttributesModel)
+              .description(customSMSDescription)
+              .build();
+
+      Response<Subscription> customSMSResponse = service.updateSubscription(customSMSUpdateSubscriptionOptions).execute();
+      // Validate response
+      assertNotNull(customSMSResponse);
+      assertEquals(customSMSResponse.getStatusCode(), 200);
+      Subscription customSMSSubscriptionResult = customSMSResponse.getResult();
+      assertNotNull(customSMSSubscriptionResult);
+      assertEquals(customSMSSubscriptionResult.getDescription(), customSMSDescription);
+      assertEquals(customSMSSubscriptionResult.getName(), customSMSName);
+      assertEquals(customSMSSubscriptionResult.getId(), subscriptionId17);
+
+
       //
       // The following status codes aren't covered by tests.
       // Please provide integration tests for these too.
@@ -2990,7 +3117,32 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test1USendNotifications() throws Exception {
+  public void test1UGetEnabledCountries() throws Exception {
+    try {
+      // begin-enabled_countries
+
+      GetEnabledCountriesOptions getEnabledCountriesOptions = new GetEnabledCountriesOptions.Builder()
+              .instanceId(instanceId)
+              .id(destinationId17)
+              .build();
+
+      // Invoke operation
+      Response<EnabledCountriesResponse> response = service.getEnabledCountries(getEnabledCountriesOptions).execute();
+      // Validate response
+      assertNotNull(response);
+      assertEquals(response.getStatusCode(), 200);
+      EnabledCountriesResponse enabledCountriesResult = response.getResult();
+      assertNotNull(enabledCountriesResult);
+
+      // end-enabled_countries
+    } catch (ServiceResponseException e) {
+      fail(String.format("Service returned status code %s: %s%nError details: %s",
+              e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+    }
+  }
+
+  @Test
+  public void test1VSendNotifications() throws Exception {
     try {
       // begin-send_notifications
       String notificationDevices = "{\"platforms\":[\"push_ios\",\"push_android\",\"push_chrome\",\"push_firefox\", \"push_huawei\"]}";
@@ -2999,6 +3151,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
       String safariJsonString = "{\"aps\":{\"alert\":{\"title\":\"FlightA998NowBoarding\",\"body\":\"BoardinghasbegunforFlightA998.\",\"action\":\"View\"},\"url-args\":[\"boarding\",\"A998\"]}}";
       String huaweiJsonString = "{\"message\":{\"android\":{\"notification\":{\"title\":\"New Message\",\"body\":\"Hello World\",\"click_action\":{\"type\":3}}}}}";
       String mailTo = "[\"abc@ibm.com\", \"def@us.ibm.com\"]";
+      String smsTo = "[\"+911234567890\", \"+911224567890\"]";
       String htmlBody = "\"Hi  ,<br/>Certificate expiring in 90 days.<br/><br/>Please login to <a href=\"https: //cloud.ibm.com/security-compliance/dashboard\">Security and Complaince dashboard</a> to find more information<br/>\"";
 
       NotificationCreate body = new NotificationCreate.Builder()
@@ -3012,6 +3165,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
               .ibmenpushto(notificationDevices)
               .ibmensubject("certificate expire")
               .ibmenmailto(mailTo)
+              .ibmensmsto(smsTo)
               .ibmenhtmlbody(htmlBody)
               .ibmenfcmbody(fcmJsonString)
               .ibmenapnsbody(apnsJsonString)
@@ -3039,7 +3193,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test1VSendBulkNotifications() throws Exception {
+  public void test1WSendBulkNotifications() throws Exception {
     try {
       String notificationDevices = "{\"user_ids\": [\"userId\"]}";
       String fcmJsonString = "{ \"title\" : \"Portugal vs. Denmark\", \"badge\": \"great match\" }";
@@ -3107,7 +3261,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test1WTestDestination() {
+  public void test1XTestDestination() {
     try {
       List<String> destinations = new ArrayList<>();
       destinations.add(destinationId4);
@@ -3134,7 +3288,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test1XDeleteSubscription() throws Exception {
+  public void test1YDeleteSubscription() throws Exception {
     try {
 
       List<String> subscriptions = new ArrayList<>();
@@ -3155,6 +3309,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
       subscriptions.add(subscriptionId14);
       subscriptions.add(subscriptionId15);
       subscriptions.add(subscriptionId16);
+      subscriptions.add(subscriptionId17);
 
       for (String subscription :
               subscriptions) {
@@ -3186,7 +3341,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test1YDeleteTopic() throws Exception {
+  public void test1ZDeleteTopic() throws Exception {
     try {
 
       List<String> topics = new ArrayList<>();
@@ -3224,7 +3379,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test1ZDeleteDestination() throws Exception {
+  public void test2ADeleteDestination() throws Exception {
     try {
       List<String> destinations = new ArrayList<>();
       destinations.add(destinationId);
@@ -3242,6 +3397,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
       destinations.add(destinationId14);
       destinations.add(destinationId15);
       destinations.add(destinationId16);
+      destinations.add(destinationId17);
 
       for (String destination :
               destinations) {
@@ -3274,7 +3430,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test2ADeleteSource() throws Exception {
+  public void test2BDeleteSource() throws Exception {
     try {
       DeleteSourceOptions deleteSourceOptions = new DeleteSourceOptions.Builder()
               .instanceId(instanceId)
@@ -3304,7 +3460,35 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test2BListIntegrations() throws Exception {
+  public void test2CCreateIntegration() throws Exception {
+    try {
+      IntegrationCreateMetadata metadata = new IntegrationCreateMetadata.Builder()
+              .endpoint(cosEndPoint)
+              .crn(cosInstanceCRN)
+              .bucketName(cosBucketName)
+              .build();
+
+      CreateIntegrationOptions integrationsOptions = new CreateIntegrationOptions.Builder()
+              .instanceId(instanceId)
+              .type("collect_failed_events")
+              .metadata(metadata)
+              .build();
+
+      // Invoke operation
+      Response<IntegrationCreateResponse> response = service.createIntegration(integrationsOptions).execute();
+      // Validate response
+      assertNotNull(response);
+      cosIntegrationID = response.getResult().getId();
+      assertEquals(response.getStatusCode(), 201);
+
+    } catch (ServiceResponseException e) {
+      fail(String.format("Service returned status code %d: %s%nError details: %s",
+              e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+    }
+  }
+
+  @Test
+  public void test2CListIntegrations() throws Exception {
     try {
       int limit = 1;
       int offset = 0;
@@ -3331,7 +3515,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test2CGetIntegration() throws Exception {
+  public void test2DGetIntegration() throws Exception {
     try {
       GetIntegrationOptions integrationsOptions = new GetIntegrationOptions.Builder()
               .instanceId(instanceId)
@@ -3351,18 +3535,18 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test2DUpdateIntegration() throws Exception {
+  public void test2EUpdateIntegration() throws Exception {
     try {
       IntegrationMetadata metadata = new IntegrationMetadata.Builder()
-              .endpoint("https://private.us-south.kms.cloud.ibm.com")
-              .crn("crn:v1:staging:public:kms:us-south:a/****:****::")
-              .rootKeyId("sddsds-f326-4688-baaf-611750e79b61")
+              .endpoint(cosEndPoint)
+              .crn(cosInstanceCRN)
+              .bucketName(cosBucketName)
               .build();
 
       ReplaceIntegrationOptions integrationsOptions = new ReplaceIntegrationOptions.Builder()
               .instanceId(instanceId)
-              .id(integrationId)
-              .type("kms")
+              .id(cosIntegrationID)
+              .type("collect_failed_events")
               .metadata(metadata)
               .build();
 
@@ -3379,7 +3563,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test2EDeleteTemplate() throws Exception {
+  public void test2FDeleteTemplate() throws Exception {
     try {
      List<String> templates = new ArrayList<>();
      templates.add(templateInvitationID);

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsTest.java
@@ -15,6 +15,7 @@ package com.ibm.cloud.eventnotifications.event_notifications.v1;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.EventNotifications;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.BulkNotificationResponse;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.CreateDestinationOptions;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.CreateIntegrationOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.CreateSourcesOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.CreateSubscriptionOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.CreateTagsSubscriptionOptions;
@@ -51,12 +52,16 @@ import com.ibm.cloud.eventnotifications.event_notifications.v1.model.Destination
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.DestinationsPager;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.EmailAttributesResponseInvitedItems;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.EmailAttributesResponseSubscribedUnsubscribedItems;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.EnabledCountriesResponse;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.GetDestinationOptions;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.GetEnabledCountriesOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.GetIntegrationOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.GetSourceOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.GetSubscriptionOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.GetTemplateOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.GetTopicOptions;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.IntegrationCreateMetadata;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.IntegrationCreateResponse;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.IntegrationGetResponse;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.IntegrationList;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.IntegrationListItem;
@@ -73,10 +78,12 @@ import com.ibm.cloud.eventnotifications.event_notifications.v1.model.Notificatio
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.NotificationResponse;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.PageHrefResponse;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.ReplaceIntegrationOptions;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.ReplaceTemplateOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.ReplaceTopicOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.Rules;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.RulesGet;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SMSAttributesItems;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SMSCountryConfig;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SMSInviteAttributesItems;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SPFAttributes;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SendBulkNotificationsOptions;
@@ -91,6 +98,7 @@ import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SourcesPage
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.Subscription;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionAttributes;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionAttributesCustomEmailAttributesResponse;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionAttributesCustomSMSAttributesResponse;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionAttributesEmailAttributesResponse;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionAttributesSMSAttributesResponse;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionAttributesServiceNowAttributesResponse;
@@ -98,6 +106,7 @@ import com.ibm.cloud.eventnotifications.event_notifications.v1.model.Subscriptio
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionAttributesWebhookAttributesResponse;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionCreateAttributes;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionCreateAttributesCustomEmailAttributes;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionCreateAttributesCustomSMSAttributes;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionCreateAttributesEmailAttributes;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionCreateAttributesFCMAttributes;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionCreateAttributesSMSAttributes;
@@ -108,6 +117,7 @@ import com.ibm.cloud.eventnotifications.event_notifications.v1.model.Subscriptio
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionListItem;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionUpdateAttributes;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionUpdateAttributesCustomEmailUpdateAttributes;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionUpdateAttributesCustomSMSUpdateAttributes;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionUpdateAttributesEmailUpdateAttributes;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionUpdateAttributesSMSUpdateAttributes;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionUpdateAttributesServiceNowAttributes;
@@ -135,7 +145,6 @@ import com.ibm.cloud.eventnotifications.event_notifications.v1.model.UpdateAttri
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.UpdateDestinationOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.UpdateSourceOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.UpdateSubscriptionOptions;
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.UpdateTemplateOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.UpdateVerifyDestinationOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.VerificationResponse;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.utils.TestUtilities;
@@ -199,6 +208,7 @@ public class EventNotificationsTest {
       .ibmendefaultshort("testString")
       .ibmendefaultlong("testString")
       .ibmensubject("testString")
+      .ibmensmsto("testString")
       .ibmenmailto("testString")
       .ibmenhtmlbody("testString")
       .subject("testString")
@@ -281,6 +291,7 @@ public class EventNotificationsTest {
       .ibmendefaultshort("testString")
       .ibmendefaultlong("testString")
       .ibmensubject("testString")
+      .ibmensmsto("testString")
       .ibmenmailto("testString")
       .ibmenhtmlbody("testString")
       .subject("testString")
@@ -1274,12 +1285,12 @@ public class EventNotificationsTest {
     eventNotificationsService.getTemplate(null).execute();
   }
 
-  // Test the updateTemplate operation with a valid options model parameter
+  // Test the replaceTemplate operation with a valid options model parameter
   @Test
-  public void testUpdateTemplateWOptions() throws Throwable {
+  public void testReplaceTemplateWOptions() throws Throwable {
     // Register a mock response
     String mockResponseBody = "{\"id\": \"id\", \"name\": \"name\", \"description\": \"description\", \"type\": \"type\", \"subscription_count\": 17, \"subscription_names\": [\"subscriptionNames\"], \"updated_at\": \"2019-01-01T12:00:00.000Z\"}";
-    String updateTemplatePath = "/v1/instances/testString/templates/testString";
+    String replaceTemplatePath = "/v1/instances/testString/templates/testString";
     server.enqueue(new MockResponse()
       .setHeader("Content-type", "application/json")
       .setResponseCode(200)
@@ -1291,8 +1302,8 @@ public class EventNotificationsTest {
       .subject("testString")
       .build();
 
-    // Construct an instance of the UpdateTemplateOptions model
-    UpdateTemplateOptions updateTemplateOptionsModel = new UpdateTemplateOptions.Builder()
+    // Construct an instance of the ReplaceTemplateOptions model
+    ReplaceTemplateOptions replaceTemplateOptionsModel = new ReplaceTemplateOptions.Builder()
       .instanceId("testString")
       .id("testString")
       .name("testString")
@@ -1301,8 +1312,8 @@ public class EventNotificationsTest {
       .params(templateConfigModel)
       .build();
 
-    // Invoke updateTemplate() with a valid options model and verify the result
-    Response<Template> response = eventNotificationsService.updateTemplate(updateTemplateOptionsModel).execute();
+    // Invoke replaceTemplate() with a valid options model and verify the result
+    Response<Template> response = eventNotificationsService.replaceTemplate(replaceTemplateOptionsModel).execute();
     assertNotNull(response);
     Template responseObj = response.getResult();
     assertNotNull(responseObj);
@@ -1313,27 +1324,27 @@ public class EventNotificationsTest {
     assertEquals(request.getMethod(), "PUT");
     // Verify request path
     String parsedPath = TestUtilities.parseReqPath(request);
-    assertEquals(parsedPath, updateTemplatePath);
+    assertEquals(parsedPath, replaceTemplatePath);
     // Verify that there is no query string
     Map<String, String> query = TestUtilities.parseQueryString(request);
     assertNull(query);
   }
 
-  // Test the updateTemplate operation with and without retries enabled
+  // Test the replaceTemplate operation with and without retries enabled
   @Test
-  public void testUpdateTemplateWRetries() throws Throwable {
+  public void testReplaceTemplateWRetries() throws Throwable {
     eventNotificationsService.enableRetries(4, 30);
-    testUpdateTemplateWOptions();
+    testReplaceTemplateWOptions();
 
     eventNotificationsService.disableRetries();
-    testUpdateTemplateWOptions();
+    testReplaceTemplateWOptions();
   }
 
-  // Test the updateTemplate operation with a null options model (negative test)
+  // Test the replaceTemplate operation with a null options model (negative test)
   @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testUpdateTemplateNoOptions() throws Throwable {
+  public void testReplaceTemplateNoOptions() throws Throwable {
     server.enqueue(new MockResponse());
-    eventNotificationsService.updateTemplate(null).execute();
+    eventNotificationsService.replaceTemplate(null).execute();
   }
 
   // Test the deleteTemplate operation with a valid options model parameter
@@ -1387,63 +1398,11 @@ public class EventNotificationsTest {
     eventNotificationsService.deleteTemplate(null).execute();
   }
 
-  // Test the testDestination operation with a valid options model parameter
-  @Test
-  public void testTestDestinationWOptions() throws Throwable {
-    // Register a mock response
-    String mockResponseBody = "{\"status\": \"status\"}";
-    String testDestinationPath = "/v1/instances/testString/destinations/testString/test";
-    server.enqueue(new MockResponse()
-      .setHeader("Content-type", "application/json")
-      .setResponseCode(200)
-      .setBody(mockResponseBody));
-
-    // Construct an instance of the TestDestinationOptions model
-    TestDestinationOptions testDestinationOptionsModel = new TestDestinationOptions.Builder()
-      .instanceId("testString")
-      .id("testString")
-      .build();
-
-    // Invoke testDestination() with a valid options model and verify the result
-    Response<TestDestinationResponse> response = eventNotificationsService.testDestination(testDestinationOptionsModel).execute();
-    assertNotNull(response);
-    TestDestinationResponse responseObj = response.getResult();
-    assertNotNull(responseObj);
-
-    // Verify the contents of the request sent to the mock server
-    RecordedRequest request = server.takeRequest();
-    assertNotNull(request);
-    assertEquals(request.getMethod(), "POST");
-    // Verify request path
-    String parsedPath = TestUtilities.parseReqPath(request);
-    assertEquals(parsedPath, testDestinationPath);
-    // Verify that there is no query string
-    Map<String, String> query = TestUtilities.parseQueryString(request);
-    assertNull(query);
-  }
-
-  // Test the testDestination operation with and without retries enabled
-  @Test
-  public void testTestDestinationWRetries() throws Throwable {
-    eventNotificationsService.enableRetries(4, 30);
-    testTestDestinationWOptions();
-
-    eventNotificationsService.disableRetries();
-    testTestDestinationWOptions();
-  }
-
-  // Test the testDestination operation with a null options model (negative test)
-  @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testTestDestinationNoOptions() throws Throwable {
-    server.enqueue(new MockResponse());
-    eventNotificationsService.testDestination(null).execute();
-  }
-
   // Test the createDestination operation with a valid options model parameter
   @Test
   public void testCreateDestinationWOptions() throws Throwable {
     // Register a mock response
-    String mockResponseBody = "{\"id\": \"id\", \"name\": \"name\", \"description\": \"description\", \"type\": \"webhook\", \"config\": {\"params\": {\"domain\": \"domain\", \"dkim\": {\"public_key\": \"publicKey\", \"selector\": \"selector\", \"verification\": \"verification\"}, \"spf\": {\"txt_name\": \"txtName\", \"txt_value\": \"txtValue\", \"verification\": \"verification\"}}}, \"created_at\": \"2019-01-01T12:00:00.000Z\"}";
+    String mockResponseBody = "{\"id\": \"id\", \"name\": \"name\", \"description\": \"description\", \"type\": \"webhook\", \"collect_failed_events\": false, \"config\": {\"params\": {\"domain\": \"domain\", \"dkim\": {\"public_key\": \"publicKey\", \"selector\": \"selector\", \"verification\": \"verification\"}, \"spf\": {\"txt_name\": \"txtName\", \"txt_value\": \"txtValue\", \"verification\": \"verification\"}}}, \"created_at\": \"2019-01-01T12:00:00.000Z\"}";
     String createDestinationPath = "/v1/instances/testString/destinations";
     server.enqueue(new MockResponse()
       .setHeader("Content-type", "application/json")
@@ -1482,6 +1441,7 @@ public class EventNotificationsTest {
       .name("testString")
       .type("webhook")
       .description("testString")
+      .collectFailedEvents(false)
       .config(destinationConfigModel)
       .certificate(TestUtilities.createMockStream("This is a mock file."))
       .certificateContentType("testString")
@@ -1538,7 +1498,7 @@ public class EventNotificationsTest {
   @Test
   public void testListDestinationsWOptions() throws Throwable {
     // Register a mock response
-    String mockResponseBody = "{\"total_count\": 10, \"offset\": 6, \"limit\": 5, \"destinations\": [{\"id\": \"id\", \"name\": \"name\", \"description\": \"description\", \"type\": \"webhook\", \"subscription_count\": 17, \"subscription_names\": [\"subscriptionNames\"], \"updated_at\": \"2019-01-01T12:00:00.000Z\"}], \"first\": {\"href\": \"href\"}, \"previous\": {\"href\": \"href\"}, \"next\": {\"href\": \"href\"}}";
+    String mockResponseBody = "{\"total_count\": 10, \"offset\": 6, \"limit\": 5, \"destinations\": [{\"id\": \"id\", \"name\": \"name\", \"description\": \"description\", \"type\": \"webhook\", \"collect_failed_events\": false, \"subscription_count\": 17, \"subscription_names\": [\"subscriptionNames\"], \"updated_at\": \"2019-01-01T12:00:00.000Z\"}], \"first\": {\"href\": \"href\"}, \"previous\": {\"href\": \"href\"}, \"next\": {\"href\": \"href\"}}";
     String listDestinationsPath = "/v1/instances/testString/destinations";
     server.enqueue(new MockResponse()
       .setHeader("Content-type", "application/json")
@@ -1595,8 +1555,8 @@ public class EventNotificationsTest {
   @Test
   public void testListDestinationsWithPagerGetNext() throws Throwable {
     // Set up the two-page mock response.
-    String mockResponsePage1 = "{\"next\":{\"href\":\"https://myhost.com/somePath?offset=1\"},\"total_count\":2,\"destinations\":[{\"id\":\"id\",\"name\":\"name\",\"description\":\"description\",\"type\":\"webhook\",\"subscription_count\":17,\"subscription_names\":[\"subscriptionNames\"],\"updated_at\":\"2019-01-01T12:00:00.000Z\"}],\"limit\":1}";
-    String mockResponsePage2 = "{\"total_count\":2,\"destinations\":[{\"id\":\"id\",\"name\":\"name\",\"description\":\"description\",\"type\":\"webhook\",\"subscription_count\":17,\"subscription_names\":[\"subscriptionNames\"],\"updated_at\":\"2019-01-01T12:00:00.000Z\"}],\"limit\":1}";
+    String mockResponsePage1 = "{\"next\":{\"href\":\"https://myhost.com/somePath?offset=1\"},\"total_count\":2,\"destinations\":[{\"id\":\"id\",\"name\":\"name\",\"description\":\"description\",\"type\":\"webhook\",\"collect_failed_events\":false,\"subscription_count\":17,\"subscription_names\":[\"subscriptionNames\"],\"updated_at\":\"2019-01-01T12:00:00.000Z\"}],\"limit\":1}";
+    String mockResponsePage2 = "{\"total_count\":2,\"destinations\":[{\"id\":\"id\",\"name\":\"name\",\"description\":\"description\",\"type\":\"webhook\",\"collect_failed_events\":false,\"subscription_count\":17,\"subscription_names\":[\"subscriptionNames\"],\"updated_at\":\"2019-01-01T12:00:00.000Z\"}],\"limit\":1}";
     server.enqueue(new MockResponse()
       .setHeader("Content-type", "application/json")
       .setResponseCode(200)
@@ -1630,8 +1590,8 @@ public class EventNotificationsTest {
   @Test
   public void testListDestinationsWithPagerGetAll() throws Throwable {
     // Set up the two-page mock response.
-    String mockResponsePage1 = "{\"next\":{\"href\":\"https://myhost.com/somePath?offset=1\"},\"total_count\":2,\"destinations\":[{\"id\":\"id\",\"name\":\"name\",\"description\":\"description\",\"type\":\"webhook\",\"subscription_count\":17,\"subscription_names\":[\"subscriptionNames\"],\"updated_at\":\"2019-01-01T12:00:00.000Z\"}],\"limit\":1}";
-    String mockResponsePage2 = "{\"total_count\":2,\"destinations\":[{\"id\":\"id\",\"name\":\"name\",\"description\":\"description\",\"type\":\"webhook\",\"subscription_count\":17,\"subscription_names\":[\"subscriptionNames\"],\"updated_at\":\"2019-01-01T12:00:00.000Z\"}],\"limit\":1}";
+    String mockResponsePage1 = "{\"next\":{\"href\":\"https://myhost.com/somePath?offset=1\"},\"total_count\":2,\"destinations\":[{\"id\":\"id\",\"name\":\"name\",\"description\":\"description\",\"type\":\"webhook\",\"collect_failed_events\":false,\"subscription_count\":17,\"subscription_names\":[\"subscriptionNames\"],\"updated_at\":\"2019-01-01T12:00:00.000Z\"}],\"limit\":1}";
+    String mockResponsePage2 = "{\"total_count\":2,\"destinations\":[{\"id\":\"id\",\"name\":\"name\",\"description\":\"description\",\"type\":\"webhook\",\"collect_failed_events\":false,\"subscription_count\":17,\"subscription_names\":[\"subscriptionNames\"],\"updated_at\":\"2019-01-01T12:00:00.000Z\"}],\"limit\":1}";
     server.enqueue(new MockResponse()
       .setHeader("Content-type", "application/json")
       .setResponseCode(200)
@@ -1661,7 +1621,7 @@ public class EventNotificationsTest {
   @Test
   public void testGetDestinationWOptions() throws Throwable {
     // Register a mock response
-    String mockResponseBody = "{\"id\": \"id\", \"name\": \"name\", \"description\": \"description\", \"type\": \"webhook\", \"config\": {\"params\": {\"domain\": \"domain\", \"dkim\": {\"public_key\": \"publicKey\", \"selector\": \"selector\", \"verification\": \"verification\"}, \"spf\": {\"txt_name\": \"txtName\", \"txt_value\": \"txtValue\", \"verification\": \"verification\"}}}, \"updated_at\": \"2019-01-01T12:00:00.000Z\", \"subscription_count\": 0, \"subscription_names\": [\"subscriptionNames\"]}";
+    String mockResponseBody = "{\"id\": \"id\", \"name\": \"name\", \"description\": \"description\", \"type\": \"webhook\", \"collect_failed_events\": false, \"config\": {\"params\": {\"domain\": \"domain\", \"dkim\": {\"public_key\": \"publicKey\", \"selector\": \"selector\", \"verification\": \"verification\"}, \"spf\": {\"txt_name\": \"txtName\", \"txt_value\": \"txtValue\", \"verification\": \"verification\"}}}, \"updated_at\": \"2019-01-01T12:00:00.000Z\", \"subscription_count\": 0, \"subscription_names\": [\"subscriptionNames\"]}";
     String getDestinationPath = "/v1/instances/testString/destinations/testString";
     server.enqueue(new MockResponse()
       .setHeader("Content-type", "application/json")
@@ -1713,7 +1673,7 @@ public class EventNotificationsTest {
   @Test
   public void testUpdateDestinationWOptions() throws Throwable {
     // Register a mock response
-    String mockResponseBody = "{\"id\": \"id\", \"name\": \"name\", \"description\": \"description\", \"type\": \"webhook\", \"config\": {\"params\": {\"domain\": \"domain\", \"dkim\": {\"public_key\": \"publicKey\", \"selector\": \"selector\", \"verification\": \"verification\"}, \"spf\": {\"txt_name\": \"txtName\", \"txt_value\": \"txtValue\", \"verification\": \"verification\"}}}, \"updated_at\": \"2019-01-01T12:00:00.000Z\", \"subscription_count\": 0, \"subscription_names\": [\"subscriptionNames\"]}";
+    String mockResponseBody = "{\"id\": \"id\", \"name\": \"name\", \"description\": \"description\", \"type\": \"webhook\", \"collect_failed_events\": false, \"config\": {\"params\": {\"domain\": \"domain\", \"dkim\": {\"public_key\": \"publicKey\", \"selector\": \"selector\", \"verification\": \"verification\"}, \"spf\": {\"txt_name\": \"txtName\", \"txt_value\": \"txtValue\", \"verification\": \"verification\"}}}, \"updated_at\": \"2019-01-01T12:00:00.000Z\", \"subscription_count\": 0, \"subscription_names\": [\"subscriptionNames\"]}";
     String updateDestinationPath = "/v1/instances/testString/destinations/testString";
     server.enqueue(new MockResponse()
       .setHeader("Content-type", "application/json")
@@ -1752,6 +1712,7 @@ public class EventNotificationsTest {
       .id("testString")
       .name("testString")
       .description("testString")
+      .collectFailedEvents(false)
       .config(destinationConfigModel)
       .certificate(TestUtilities.createMockStream("This is a mock file."))
       .certificateContentType("testString")
@@ -1853,6 +1814,110 @@ public class EventNotificationsTest {
   public void testDeleteDestinationNoOptions() throws Throwable {
     server.enqueue(new MockResponse());
     eventNotificationsService.deleteDestination(null).execute();
+  }
+
+  // Test the getEnabledCountries operation with a valid options model parameter
+  @Test
+  public void testGetEnabledCountriesWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"status\": \"status\", \"enabled_countries\": [{\"number\": \"number\", \"country\": [\"country\"]}]}";
+    String getEnabledCountriesPath = "/v1/instances/testString/destinations/testString/enabled_countries";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the GetEnabledCountriesOptions model
+    GetEnabledCountriesOptions getEnabledCountriesOptionsModel = new GetEnabledCountriesOptions.Builder()
+      .instanceId("testString")
+      .id("testString")
+      .build();
+
+    // Invoke getEnabledCountries() with a valid options model and verify the result
+    Response<EnabledCountriesResponse> response = eventNotificationsService.getEnabledCountries(getEnabledCountriesOptionsModel).execute();
+    assertNotNull(response);
+    EnabledCountriesResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "GET");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, getEnabledCountriesPath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the getEnabledCountries operation with and without retries enabled
+  @Test
+  public void testGetEnabledCountriesWRetries() throws Throwable {
+    eventNotificationsService.enableRetries(4, 30);
+    testGetEnabledCountriesWOptions();
+
+    eventNotificationsService.disableRetries();
+    testGetEnabledCountriesWOptions();
+  }
+
+  // Test the getEnabledCountries operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGetEnabledCountriesNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    eventNotificationsService.getEnabledCountries(null).execute();
+  }
+
+  // Test the testDestination operation with a valid options model parameter
+  @Test
+  public void testTestDestinationWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"status\": \"status\"}";
+    String testDestinationPath = "/v1/instances/testString/destinations/testString/test";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(201)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the TestDestinationOptions model
+    TestDestinationOptions testDestinationOptionsModel = new TestDestinationOptions.Builder()
+      .instanceId("testString")
+      .id("testString")
+      .build();
+
+    // Invoke testDestination() with a valid options model and verify the result
+    Response<TestDestinationResponse> response = eventNotificationsService.testDestination(testDestinationOptionsModel).execute();
+    assertNotNull(response);
+    TestDestinationResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "POST");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, testDestinationPath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the testDestination operation with and without retries enabled
+  @Test
+  public void testTestDestinationWRetries() throws Throwable {
+    eventNotificationsService.enableRetries(4, 30);
+    testTestDestinationWOptions();
+
+    eventNotificationsService.disableRetries();
+    testTestDestinationWOptions();
+  }
+
+  // Test the testDestination operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testTestDestinationNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    eventNotificationsService.testDestination(null).execute();
   }
 
   // Test the updateVerifyDestination operation with a valid options model parameter
@@ -2521,11 +2586,71 @@ public class EventNotificationsTest {
     eventNotificationsService.updateSubscription(null).execute();
   }
 
+  // Test the createIntegration operation with a valid options model parameter
+  @Test
+  public void testCreateIntegrationWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"id\": \"9fab83da-98cb-4f18-a7ba-b6f0435c9673\", \"type\": \"type\", \"metadata\": {\"endpoint\": \"endpoint\", \"crn\": \"crn\", \"bucket_name\": \"bucketName\"}, \"created_at\": \"2019-01-01T12:00:00.000Z\"}";
+    String createIntegrationPath = "/v1/instances/testString/integrations";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the IntegrationCreateMetadata model
+    IntegrationCreateMetadata integrationCreateMetadataModel = new IntegrationCreateMetadata.Builder()
+      .endpoint("testString")
+      .crn("testString")
+      .bucketName("testString")
+      .build();
+
+    // Construct an instance of the CreateIntegrationOptions model
+    CreateIntegrationOptions createIntegrationOptionsModel = new CreateIntegrationOptions.Builder()
+      .instanceId("testString")
+      .type("collect_failed_events")
+      .metadata(integrationCreateMetadataModel)
+      .build();
+
+    // Invoke createIntegration() with a valid options model and verify the result
+    Response<IntegrationCreateResponse> response = eventNotificationsService.createIntegration(createIntegrationOptionsModel).execute();
+    assertNotNull(response);
+    IntegrationCreateResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "POST");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, createIntegrationPath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the createIntegration operation with and without retries enabled
+  @Test
+  public void testCreateIntegrationWRetries() throws Throwable {
+    eventNotificationsService.enableRetries(4, 30);
+    testCreateIntegrationWOptions();
+
+    eventNotificationsService.disableRetries();
+    testCreateIntegrationWOptions();
+  }
+
+  // Test the createIntegration operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testCreateIntegrationNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    eventNotificationsService.createIntegration(null).execute();
+  }
+
   // Test the listIntegrations operation with a valid options model parameter
   @Test
   public void testListIntegrationsWOptions() throws Throwable {
     // Register a mock response
-    String mockResponseBody = "{\"total_count\": 0, \"offset\": 6, \"limit\": 5, \"integrations\": [{\"id\": \"9fab83da-98cb-4f18-a7ba-b6f0435c9673\", \"type\": \"type\", \"metadata\": {\"endpoint\": \"endpoint\", \"crn\": \"crn\", \"root_key_id\": \"rootKeyId\"}, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"updated_at\": \"2019-01-01T12:00:00.000Z\"}], \"first\": {\"href\": \"href\"}, \"previous\": {\"href\": \"href\"}, \"next\": {\"href\": \"href\"}}";
+    String mockResponseBody = "{\"total_count\": 0, \"offset\": 6, \"limit\": 5, \"integrations\": [{\"id\": \"9fab83da-98cb-4f18-a7ba-b6f0435c9673\", \"type\": \"type\", \"metadata\": {\"endpoint\": \"endpoint\", \"crn\": \"crn\", \"root_key_id\": \"rootKeyId\", \"bucket_name\": \"bucketName\"}, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"updated_at\": \"2019-01-01T12:00:00.000Z\"}], \"first\": {\"href\": \"href\"}, \"previous\": {\"href\": \"href\"}, \"next\": {\"href\": \"href\"}}";
     String listIntegrationsPath = "/v1/instances/testString/integrations";
     server.enqueue(new MockResponse()
       .setHeader("Content-type", "application/json")
@@ -2582,8 +2707,8 @@ public class EventNotificationsTest {
   @Test
   public void testListIntegrationsWithPagerGetNext() throws Throwable {
     // Set up the two-page mock response.
-    String mockResponsePage1 = "{\"next\":{\"href\":\"https://myhost.com/somePath?offset=1\"},\"total_count\":2,\"limit\":1,\"integrations\":[{\"id\":\"9fab83da-98cb-4f18-a7ba-b6f0435c9673\",\"type\":\"type\",\"metadata\":{\"endpoint\":\"endpoint\",\"crn\":\"crn\",\"root_key_id\":\"rootKeyId\"},\"created_at\":\"2019-01-01T12:00:00.000Z\",\"updated_at\":\"2019-01-01T12:00:00.000Z\"}]}";
-    String mockResponsePage2 = "{\"total_count\":2,\"limit\":1,\"integrations\":[{\"id\":\"9fab83da-98cb-4f18-a7ba-b6f0435c9673\",\"type\":\"type\",\"metadata\":{\"endpoint\":\"endpoint\",\"crn\":\"crn\",\"root_key_id\":\"rootKeyId\"},\"created_at\":\"2019-01-01T12:00:00.000Z\",\"updated_at\":\"2019-01-01T12:00:00.000Z\"}]}";
+    String mockResponsePage1 = "{\"next\":{\"href\":\"https://myhost.com/somePath?offset=1\"},\"total_count\":2,\"limit\":1,\"integrations\":[{\"id\":\"9fab83da-98cb-4f18-a7ba-b6f0435c9673\",\"type\":\"type\",\"metadata\":{\"endpoint\":\"endpoint\",\"crn\":\"crn\",\"root_key_id\":\"rootKeyId\",\"bucket_name\":\"bucketName\"},\"created_at\":\"2019-01-01T12:00:00.000Z\",\"updated_at\":\"2019-01-01T12:00:00.000Z\"}]}";
+    String mockResponsePage2 = "{\"total_count\":2,\"limit\":1,\"integrations\":[{\"id\":\"9fab83da-98cb-4f18-a7ba-b6f0435c9673\",\"type\":\"type\",\"metadata\":{\"endpoint\":\"endpoint\",\"crn\":\"crn\",\"root_key_id\":\"rootKeyId\",\"bucket_name\":\"bucketName\"},\"created_at\":\"2019-01-01T12:00:00.000Z\",\"updated_at\":\"2019-01-01T12:00:00.000Z\"}]}";
     server.enqueue(new MockResponse()
       .setHeader("Content-type", "application/json")
       .setResponseCode(200)
@@ -2617,8 +2742,8 @@ public class EventNotificationsTest {
   @Test
   public void testListIntegrationsWithPagerGetAll() throws Throwable {
     // Set up the two-page mock response.
-    String mockResponsePage1 = "{\"next\":{\"href\":\"https://myhost.com/somePath?offset=1\"},\"total_count\":2,\"limit\":1,\"integrations\":[{\"id\":\"9fab83da-98cb-4f18-a7ba-b6f0435c9673\",\"type\":\"type\",\"metadata\":{\"endpoint\":\"endpoint\",\"crn\":\"crn\",\"root_key_id\":\"rootKeyId\"},\"created_at\":\"2019-01-01T12:00:00.000Z\",\"updated_at\":\"2019-01-01T12:00:00.000Z\"}]}";
-    String mockResponsePage2 = "{\"total_count\":2,\"limit\":1,\"integrations\":[{\"id\":\"9fab83da-98cb-4f18-a7ba-b6f0435c9673\",\"type\":\"type\",\"metadata\":{\"endpoint\":\"endpoint\",\"crn\":\"crn\",\"root_key_id\":\"rootKeyId\"},\"created_at\":\"2019-01-01T12:00:00.000Z\",\"updated_at\":\"2019-01-01T12:00:00.000Z\"}]}";
+    String mockResponsePage1 = "{\"next\":{\"href\":\"https://myhost.com/somePath?offset=1\"},\"total_count\":2,\"limit\":1,\"integrations\":[{\"id\":\"9fab83da-98cb-4f18-a7ba-b6f0435c9673\",\"type\":\"type\",\"metadata\":{\"endpoint\":\"endpoint\",\"crn\":\"crn\",\"root_key_id\":\"rootKeyId\",\"bucket_name\":\"bucketName\"},\"created_at\":\"2019-01-01T12:00:00.000Z\",\"updated_at\":\"2019-01-01T12:00:00.000Z\"}]}";
+    String mockResponsePage2 = "{\"total_count\":2,\"limit\":1,\"integrations\":[{\"id\":\"9fab83da-98cb-4f18-a7ba-b6f0435c9673\",\"type\":\"type\",\"metadata\":{\"endpoint\":\"endpoint\",\"crn\":\"crn\",\"root_key_id\":\"rootKeyId\",\"bucket_name\":\"bucketName\"},\"created_at\":\"2019-01-01T12:00:00.000Z\",\"updated_at\":\"2019-01-01T12:00:00.000Z\"}]}";
     server.enqueue(new MockResponse()
       .setHeader("Content-type", "application/json")
       .setResponseCode(200)
@@ -2648,7 +2773,7 @@ public class EventNotificationsTest {
   @Test
   public void testGetIntegrationWOptions() throws Throwable {
     // Register a mock response
-    String mockResponseBody = "{\"id\": \"9fab83da-98cb-4f18-a7ba-b6f0435c9673\", \"type\": \"type\", \"metadata\": {\"endpoint\": \"endpoint\", \"crn\": \"crn\", \"root_key_id\": \"rootKeyId\"}, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"updated_at\": \"2019-01-01T12:00:00.000Z\"}";
+    String mockResponseBody = "{\"id\": \"9fab83da-98cb-4f18-a7ba-b6f0435c9673\", \"type\": \"type\", \"metadata\": {\"endpoint\": \"endpoint\", \"crn\": \"crn\", \"root_key_id\": \"rootKeyId\", \"bucket_name\": \"bucketName\"}, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"updated_at\": \"2019-01-01T12:00:00.000Z\"}";
     String getIntegrationPath = "/v1/instances/testString/integrations/testString";
     server.enqueue(new MockResponse()
       .setHeader("Content-type", "application/json")
@@ -2700,7 +2825,7 @@ public class EventNotificationsTest {
   @Test
   public void testReplaceIntegrationWOptions() throws Throwable {
     // Register a mock response
-    String mockResponseBody = "{\"id\": \"9fab83da-98cb-4f18-a7ba-b6f0435c9673\", \"type\": \"type\", \"metadata\": {\"endpoint\": \"endpoint\", \"crn\": \"crn\", \"root_key_id\": \"rootKeyId\"}, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"updated_at\": \"2019-01-01T12:00:00.000Z\"}";
+    String mockResponseBody = "{\"id\": \"9fab83da-98cb-4f18-a7ba-b6f0435c9673\", \"type\": \"type\", \"metadata\": {\"endpoint\": \"endpoint\", \"crn\": \"crn\", \"root_key_id\": \"rootKeyId\", \"bucket_name\": \"bucketName\"}, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"updated_at\": \"2019-01-01T12:00:00.000Z\"}";
     String replaceIntegrationPath = "/v1/instances/testString/integrations/testString";
     server.enqueue(new MockResponse()
       .setHeader("Content-type", "application/json")
@@ -2712,6 +2837,7 @@ public class EventNotificationsTest {
       .endpoint("testString")
       .crn("testString")
       .rootKeyId("testString")
+      .bucketName("testString")
       .build();
 
     // Construct an instance of the ReplaceIntegrationOptions model

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateDestinationOptionsTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateDestinationOptionsTest.java
@@ -73,6 +73,7 @@ public class CreateDestinationOptionsTest {
       .name("testString")
       .type("webhook")
       .description("testString")
+      .collectFailedEvents(false)
       .config(destinationConfigModel)
       .certificate(TestUtilities.createMockStream("This is a mock file."))
       .certificateContentType("testString")
@@ -93,6 +94,7 @@ public class CreateDestinationOptionsTest {
     assertEquals(createDestinationOptionsModel.name(), "testString");
     assertEquals(createDestinationOptionsModel.type(), "webhook");
     assertEquals(createDestinationOptionsModel.description(), "testString");
+    assertEquals(createDestinationOptionsModel.collectFailedEvents(), Boolean.valueOf(false));
     assertEquals(createDestinationOptionsModel.config(), destinationConfigModel);
     assertEquals(IOUtils.toString(createDestinationOptionsModel.certificate()), IOUtils.toString(TestUtilities.createMockStream("This is a mock file.")));
     assertEquals(createDestinationOptionsModel.certificateContentType(), "testString");

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateIntegrationOptionsTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/CreateIntegrationOptionsTest.java
@@ -13,7 +13,8 @@
 
 package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
 
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.IntegrationMetadata;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.CreateIntegrationOptions;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.IntegrationCreateMetadata;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.utils.TestUtilities;
 import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
 import java.io.InputStream;
@@ -23,38 +24,36 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 /**
- * Unit test class for the IntegrationMetadata model.
+ * Unit test class for the CreateIntegrationOptions model.
  */
-public class IntegrationMetadataTest {
+public class CreateIntegrationOptionsTest {
   final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
   final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
 
   @Test
-  public void testIntegrationMetadata() throws Throwable {
-    IntegrationMetadata integrationMetadataModel = new IntegrationMetadata.Builder()
+  public void testCreateIntegrationOptions() throws Throwable {
+    IntegrationCreateMetadata integrationCreateMetadataModel = new IntegrationCreateMetadata.Builder()
       .endpoint("testString")
       .crn("testString")
-      .rootKeyId("testString")
       .bucketName("testString")
       .build();
-    assertEquals(integrationMetadataModel.endpoint(), "testString");
-    assertEquals(integrationMetadataModel.crn(), "testString");
-    assertEquals(integrationMetadataModel.rootKeyId(), "testString");
-    assertEquals(integrationMetadataModel.bucketName(), "testString");
+    assertEquals(integrationCreateMetadataModel.endpoint(), "testString");
+    assertEquals(integrationCreateMetadataModel.crn(), "testString");
+    assertEquals(integrationCreateMetadataModel.bucketName(), "testString");
 
-    String json = TestUtilities.serialize(integrationMetadataModel);
-
-    IntegrationMetadata integrationMetadataModelNew = TestUtilities.deserialize(json, IntegrationMetadata.class);
-    assertTrue(integrationMetadataModelNew instanceof IntegrationMetadata);
-    assertEquals(integrationMetadataModelNew.endpoint(), "testString");
-    assertEquals(integrationMetadataModelNew.crn(), "testString");
-    assertEquals(integrationMetadataModelNew.rootKeyId(), "testString");
-    assertEquals(integrationMetadataModelNew.bucketName(), "testString");
+    CreateIntegrationOptions createIntegrationOptionsModel = new CreateIntegrationOptions.Builder()
+      .instanceId("testString")
+      .type("collect_failed_events")
+      .metadata(integrationCreateMetadataModel)
+      .build();
+    assertEquals(createIntegrationOptionsModel.instanceId(), "testString");
+    assertEquals(createIntegrationOptionsModel.type(), "collect_failed_events");
+    assertEquals(createIntegrationOptionsModel.metadata(), integrationCreateMetadataModel);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testIntegrationMetadataError() throws Throwable {
-    new IntegrationMetadata.Builder().build();
+  public void testCreateIntegrationOptionsError() throws Throwable {
+    new CreateIntegrationOptions.Builder().build();
   }
 
 }

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationListItemTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationListItemTest.java
@@ -36,6 +36,7 @@ public class DestinationListItemTest {
     assertNull(destinationListItemModel.getName());
     assertNull(destinationListItemModel.getDescription());
     assertNull(destinationListItemModel.getType());
+    assertNull(destinationListItemModel.isCollectFailedEvents());
     assertNull(destinationListItemModel.getSubscriptionCount());
     assertNull(destinationListItemModel.getSubscriptionNames());
     assertNull(destinationListItemModel.getUpdatedAt());

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationResponseTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationResponseTest.java
@@ -38,6 +38,7 @@ public class DestinationResponseTest {
     assertNull(destinationResponseModel.getName());
     assertNull(destinationResponseModel.getDescription());
     assertNull(destinationResponseModel.getType());
+    assertNull(destinationResponseModel.isCollectFailedEvents());
     assertNull(destinationResponseModel.getConfig());
     assertNull(destinationResponseModel.getCreatedAt());
   }

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/EnabledCountriesResponseTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/EnabledCountriesResponseTest.java
@@ -13,9 +13,8 @@
 
 package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
 
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.Destination;
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.DestinationConfig;
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.DestinationConfigOneOfWebhookDestinationConfig;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.EnabledCountriesResponse;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SMSCountryConfig;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.utils.TestUtilities;
 import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
 import java.io.InputStream;
@@ -25,23 +24,16 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 /**
- * Unit test class for the Destination model.
+ * Unit test class for the EnabledCountriesResponse model.
  */
-public class DestinationTest {
+public class EnabledCountriesResponseTest {
   final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
   final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
 
   @Test
-  public void testDestination() throws Throwable {
-    Destination destinationModel = new Destination();
-    assertNull(destinationModel.getId());
-    assertNull(destinationModel.getName());
-    assertNull(destinationModel.getDescription());
-    assertNull(destinationModel.getType());
-    assertNull(destinationModel.isCollectFailedEvents());
-    assertNull(destinationModel.getConfig());
-    assertNull(destinationModel.getUpdatedAt());
-    assertNull(destinationModel.getSubscriptionCount());
-    assertNull(destinationModel.getSubscriptionNames());
+  public void testEnabledCountriesResponse() throws Throwable {
+    EnabledCountriesResponse enabledCountriesResponseModel = new EnabledCountriesResponse();
+    assertNull(enabledCountriesResponseModel.getStatus());
+    assertNull(enabledCountriesResponseModel.getEnabledCountries());
   }
 }

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetEnabledCountriesOptionsTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetEnabledCountriesOptionsTest.java
@@ -13,9 +13,7 @@
 
 package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
 
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.Destination;
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.DestinationConfig;
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.DestinationConfigOneOfWebhookDestinationConfig;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.GetEnabledCountriesOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.utils.TestUtilities;
 import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
 import java.io.InputStream;
@@ -25,23 +23,25 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 /**
- * Unit test class for the Destination model.
+ * Unit test class for the GetEnabledCountriesOptions model.
  */
-public class DestinationTest {
+public class GetEnabledCountriesOptionsTest {
   final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
   final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
 
   @Test
-  public void testDestination() throws Throwable {
-    Destination destinationModel = new Destination();
-    assertNull(destinationModel.getId());
-    assertNull(destinationModel.getName());
-    assertNull(destinationModel.getDescription());
-    assertNull(destinationModel.getType());
-    assertNull(destinationModel.isCollectFailedEvents());
-    assertNull(destinationModel.getConfig());
-    assertNull(destinationModel.getUpdatedAt());
-    assertNull(destinationModel.getSubscriptionCount());
-    assertNull(destinationModel.getSubscriptionNames());
+  public void testGetEnabledCountriesOptions() throws Throwable {
+    GetEnabledCountriesOptions getEnabledCountriesOptionsModel = new GetEnabledCountriesOptions.Builder()
+      .instanceId("testString")
+      .id("testString")
+      .build();
+    assertEquals(getEnabledCountriesOptionsModel.instanceId(), "testString");
+    assertEquals(getEnabledCountriesOptionsModel.id(), "testString");
   }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGetEnabledCountriesOptionsError() throws Throwable {
+    new GetEnabledCountriesOptions.Builder().build();
+  }
+
 }

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/IntegrationCreateMetadataTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/IntegrationCreateMetadataTest.java
@@ -13,7 +13,7 @@
 
 package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
 
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.IntegrationMetadata;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.IntegrationCreateMetadata;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.utils.TestUtilities;
 import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
 import java.io.InputStream;
@@ -23,38 +23,35 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 /**
- * Unit test class for the IntegrationMetadata model.
+ * Unit test class for the IntegrationCreateMetadata model.
  */
-public class IntegrationMetadataTest {
+public class IntegrationCreateMetadataTest {
   final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
   final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
 
   @Test
-  public void testIntegrationMetadata() throws Throwable {
-    IntegrationMetadata integrationMetadataModel = new IntegrationMetadata.Builder()
+  public void testIntegrationCreateMetadata() throws Throwable {
+    IntegrationCreateMetadata integrationCreateMetadataModel = new IntegrationCreateMetadata.Builder()
       .endpoint("testString")
       .crn("testString")
-      .rootKeyId("testString")
       .bucketName("testString")
       .build();
-    assertEquals(integrationMetadataModel.endpoint(), "testString");
-    assertEquals(integrationMetadataModel.crn(), "testString");
-    assertEquals(integrationMetadataModel.rootKeyId(), "testString");
-    assertEquals(integrationMetadataModel.bucketName(), "testString");
+    assertEquals(integrationCreateMetadataModel.endpoint(), "testString");
+    assertEquals(integrationCreateMetadataModel.crn(), "testString");
+    assertEquals(integrationCreateMetadataModel.bucketName(), "testString");
 
-    String json = TestUtilities.serialize(integrationMetadataModel);
+    String json = TestUtilities.serialize(integrationCreateMetadataModel);
 
-    IntegrationMetadata integrationMetadataModelNew = TestUtilities.deserialize(json, IntegrationMetadata.class);
-    assertTrue(integrationMetadataModelNew instanceof IntegrationMetadata);
-    assertEquals(integrationMetadataModelNew.endpoint(), "testString");
-    assertEquals(integrationMetadataModelNew.crn(), "testString");
-    assertEquals(integrationMetadataModelNew.rootKeyId(), "testString");
-    assertEquals(integrationMetadataModelNew.bucketName(), "testString");
+    IntegrationCreateMetadata integrationCreateMetadataModelNew = TestUtilities.deserialize(json, IntegrationCreateMetadata.class);
+    assertTrue(integrationCreateMetadataModelNew instanceof IntegrationCreateMetadata);
+    assertEquals(integrationCreateMetadataModelNew.endpoint(), "testString");
+    assertEquals(integrationCreateMetadataModelNew.crn(), "testString");
+    assertEquals(integrationCreateMetadataModelNew.bucketName(), "testString");
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testIntegrationMetadataError() throws Throwable {
-    new IntegrationMetadata.Builder().build();
+  public void testIntegrationCreateMetadataError() throws Throwable {
+    new IntegrationCreateMetadata.Builder().build();
   }
 
 }

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/IntegrationCreateResponseTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/IntegrationCreateResponseTest.java
@@ -13,9 +13,8 @@
 
 package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
 
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.Destination;
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.DestinationConfig;
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.DestinationConfigOneOfWebhookDestinationConfig;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.IntegrationCreateMetadata;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.IntegrationCreateResponse;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.utils.TestUtilities;
 import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
 import java.io.InputStream;
@@ -25,23 +24,18 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 /**
- * Unit test class for the Destination model.
+ * Unit test class for the IntegrationCreateResponse model.
  */
-public class DestinationTest {
+public class IntegrationCreateResponseTest {
   final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
   final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
 
   @Test
-  public void testDestination() throws Throwable {
-    Destination destinationModel = new Destination();
-    assertNull(destinationModel.getId());
-    assertNull(destinationModel.getName());
-    assertNull(destinationModel.getDescription());
-    assertNull(destinationModel.getType());
-    assertNull(destinationModel.isCollectFailedEvents());
-    assertNull(destinationModel.getConfig());
-    assertNull(destinationModel.getUpdatedAt());
-    assertNull(destinationModel.getSubscriptionCount());
-    assertNull(destinationModel.getSubscriptionNames());
+  public void testIntegrationCreateResponse() throws Throwable {
+    IntegrationCreateResponse integrationCreateResponseModel = new IntegrationCreateResponse();
+    assertNull(integrationCreateResponseModel.getId());
+    assertNull(integrationCreateResponseModel.getType());
+    assertNull(integrationCreateResponseModel.getMetadata());
+    assertNull(integrationCreateResponseModel.getCreatedAt());
   }
 }

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/NotificationCreateTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/NotificationCreateTest.java
@@ -43,6 +43,7 @@ public class NotificationCreateTest {
       .ibmendefaultshort("testString")
       .ibmendefaultlong("testString")
       .ibmensubject("testString")
+      .ibmensmsto("testString")
       .ibmenmailto("testString")
       .ibmenhtmlbody("testString")
       .subject("testString")
@@ -70,6 +71,7 @@ public class NotificationCreateTest {
     assertEquals(notificationCreateModel.getIbmendefaultshort(), "testString");
     assertEquals(notificationCreateModel.getIbmendefaultlong(), "testString");
     assertEquals(notificationCreateModel.getIbmensubject(), "testString");
+    assertEquals(notificationCreateModel.getIbmensmsto(), "testString");
     assertEquals(notificationCreateModel.getIbmenmailto(), "testString");
     assertEquals(notificationCreateModel.getIbmenhtmlbody(), "testString");
     assertEquals(notificationCreateModel.getSubject(), "testString");
@@ -101,6 +103,7 @@ public class NotificationCreateTest {
     assertEquals(notificationCreateModelNew.getIbmendefaultshort(), "testString");
     assertEquals(notificationCreateModelNew.getIbmendefaultlong(), "testString");
     assertEquals(notificationCreateModelNew.getIbmensubject(), "testString");
+    assertEquals(notificationCreateModelNew.getIbmensmsto(), "testString");
     assertEquals(notificationCreateModelNew.getIbmenmailto(), "testString");
     assertEquals(notificationCreateModelNew.getIbmenhtmlbody(), "testString");
     assertEquals(notificationCreateModelNew.getSubject(), "testString");

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ReplaceIntegrationOptionsTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ReplaceIntegrationOptionsTest.java
@@ -36,10 +36,12 @@ public class ReplaceIntegrationOptionsTest {
       .endpoint("testString")
       .crn("testString")
       .rootKeyId("testString")
+      .bucketName("testString")
       .build();
     assertEquals(integrationMetadataModel.endpoint(), "testString");
     assertEquals(integrationMetadataModel.crn(), "testString");
     assertEquals(integrationMetadataModel.rootKeyId(), "testString");
+    assertEquals(integrationMetadataModel.bucketName(), "testString");
 
     ReplaceIntegrationOptions replaceIntegrationOptionsModel = new ReplaceIntegrationOptions.Builder()
       .instanceId("testString")

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ReplaceTemplateOptionsTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/ReplaceTemplateOptionsTest.java
@@ -13,8 +13,8 @@
 
 package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
 
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.ReplaceTemplateOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.model.TemplateConfig;
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.UpdateTemplateOptions;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.utils.TestUtilities;
 import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
 import java.io.InputStream;
@@ -24,14 +24,14 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 /**
- * Unit test class for the UpdateTemplateOptions model.
+ * Unit test class for the ReplaceTemplateOptions model.
  */
-public class UpdateTemplateOptionsTest {
+public class ReplaceTemplateOptionsTest {
   final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
   final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
 
   @Test
-  public void testUpdateTemplateOptions() throws Throwable {
+  public void testReplaceTemplateOptions() throws Throwable {
     TemplateConfig templateConfigModel = new TemplateConfig.Builder()
       .body("testString")
       .subject("testString")
@@ -39,7 +39,7 @@ public class UpdateTemplateOptionsTest {
     assertEquals(templateConfigModel.body(), "testString");
     assertEquals(templateConfigModel.subject(), "testString");
 
-    UpdateTemplateOptions updateTemplateOptionsModel = new UpdateTemplateOptions.Builder()
+    ReplaceTemplateOptions replaceTemplateOptionsModel = new ReplaceTemplateOptions.Builder()
       .instanceId("testString")
       .id("testString")
       .name("testString")
@@ -47,17 +47,17 @@ public class UpdateTemplateOptionsTest {
       .type("testString")
       .params(templateConfigModel)
       .build();
-    assertEquals(updateTemplateOptionsModel.instanceId(), "testString");
-    assertEquals(updateTemplateOptionsModel.id(), "testString");
-    assertEquals(updateTemplateOptionsModel.name(), "testString");
-    assertEquals(updateTemplateOptionsModel.description(), "testString");
-    assertEquals(updateTemplateOptionsModel.type(), "testString");
-    assertEquals(updateTemplateOptionsModel.params(), templateConfigModel);
+    assertEquals(replaceTemplateOptionsModel.instanceId(), "testString");
+    assertEquals(replaceTemplateOptionsModel.id(), "testString");
+    assertEquals(replaceTemplateOptionsModel.name(), "testString");
+    assertEquals(replaceTemplateOptionsModel.description(), "testString");
+    assertEquals(replaceTemplateOptionsModel.type(), "testString");
+    assertEquals(replaceTemplateOptionsModel.params(), templateConfigModel);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testUpdateTemplateOptionsError() throws Throwable {
-    new UpdateTemplateOptions.Builder().build();
+  public void testReplaceTemplateOptionsError() throws Throwable {
+    new ReplaceTemplateOptions.Builder().build();
   }
 
 }

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SMSCountryConfigTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SMSCountryConfigTest.java
@@ -13,9 +13,7 @@
 
 package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
 
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.Destination;
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.DestinationConfig;
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.DestinationConfigOneOfWebhookDestinationConfig;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SMSCountryConfig;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.utils.TestUtilities;
 import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
 import java.io.InputStream;
@@ -25,23 +23,16 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 /**
- * Unit test class for the Destination model.
+ * Unit test class for the SMSCountryConfig model.
  */
-public class DestinationTest {
+public class SMSCountryConfigTest {
   final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
   final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
 
   @Test
-  public void testDestination() throws Throwable {
-    Destination destinationModel = new Destination();
-    assertNull(destinationModel.getId());
-    assertNull(destinationModel.getName());
-    assertNull(destinationModel.getDescription());
-    assertNull(destinationModel.getType());
-    assertNull(destinationModel.isCollectFailedEvents());
-    assertNull(destinationModel.getConfig());
-    assertNull(destinationModel.getUpdatedAt());
-    assertNull(destinationModel.getSubscriptionCount());
-    assertNull(destinationModel.getSubscriptionNames());
+  public void testSMSCountryConfig() throws Throwable {
+    SMSCountryConfig smsCountryConfigModel = new SMSCountryConfig();
+    assertNull(smsCountryConfigModel.getNumber());
+    assertNull(smsCountryConfigModel.getCountry());
   }
 }

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SendBulkNotificationsOptionsTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SendBulkNotificationsOptionsTest.java
@@ -44,6 +44,7 @@ public class SendBulkNotificationsOptionsTest {
       .ibmendefaultshort("testString")
       .ibmendefaultlong("testString")
       .ibmensubject("testString")
+      .ibmensmsto("testString")
       .ibmenmailto("testString")
       .ibmenhtmlbody("testString")
       .subject("testString")
@@ -71,6 +72,7 @@ public class SendBulkNotificationsOptionsTest {
     assertEquals(notificationCreateModel.getIbmendefaultshort(), "testString");
     assertEquals(notificationCreateModel.getIbmendefaultlong(), "testString");
     assertEquals(notificationCreateModel.getIbmensubject(), "testString");
+    assertEquals(notificationCreateModel.getIbmensmsto(), "testString");
     assertEquals(notificationCreateModel.getIbmenmailto(), "testString");
     assertEquals(notificationCreateModel.getIbmenhtmlbody(), "testString");
     assertEquals(notificationCreateModel.getSubject(), "testString");

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SendNotificationsOptionsTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SendNotificationsOptionsTest.java
@@ -44,6 +44,7 @@ public class SendNotificationsOptionsTest {
       .ibmendefaultshort("testString")
       .ibmendefaultlong("testString")
       .ibmensubject("testString")
+      .ibmensmsto("testString")
       .ibmenmailto("testString")
       .ibmenhtmlbody("testString")
       .subject("testString")
@@ -71,6 +72,7 @@ public class SendNotificationsOptionsTest {
     assertEquals(notificationCreateModel.getIbmendefaultshort(), "testString");
     assertEquals(notificationCreateModel.getIbmendefaultlong(), "testString");
     assertEquals(notificationCreateModel.getIbmensubject(), "testString");
+    assertEquals(notificationCreateModel.getIbmensmsto(), "testString");
     assertEquals(notificationCreateModel.getIbmenmailto(), "testString");
     assertEquals(notificationCreateModel.getIbmenhtmlbody(), "testString");
     assertEquals(notificationCreateModel.getSubject(), "testString");

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionAttributesCustomSMSAttributesResponseTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionAttributesCustomSMSAttributesResponseTest.java
@@ -13,11 +13,12 @@
 
 package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
 
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.Destination;
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.DestinationConfig;
-import com.ibm.cloud.eventnotifications.event_notifications.v1.model.DestinationConfigOneOfWebhookDestinationConfig;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SMSAttributesItems;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SMSInviteAttributesItems;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionAttributesCustomSMSAttributesResponse;
 import com.ibm.cloud.eventnotifications.event_notifications.v1.utils.TestUtilities;
 import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import com.ibm.cloud.sdk.core.util.DateUtils;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
@@ -25,23 +26,17 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 /**
- * Unit test class for the Destination model.
+ * Unit test class for the SubscriptionAttributesCustomSMSAttributesResponse model.
  */
-public class DestinationTest {
+public class SubscriptionAttributesCustomSMSAttributesResponseTest {
   final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
   final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
 
   @Test
-  public void testDestination() throws Throwable {
-    Destination destinationModel = new Destination();
-    assertNull(destinationModel.getId());
-    assertNull(destinationModel.getName());
-    assertNull(destinationModel.getDescription());
-    assertNull(destinationModel.getType());
-    assertNull(destinationModel.isCollectFailedEvents());
-    assertNull(destinationModel.getConfig());
-    assertNull(destinationModel.getUpdatedAt());
-    assertNull(destinationModel.getSubscriptionCount());
-    assertNull(destinationModel.getSubscriptionNames());
+  public void testSubscriptionAttributesCustomSMSAttributesResponse() throws Throwable {
+    SubscriptionAttributesCustomSMSAttributesResponse subscriptionAttributesCustomSmsAttributesResponseModel = new SubscriptionAttributesCustomSMSAttributesResponse();
+    assertNull(subscriptionAttributesCustomSmsAttributesResponseModel.getSubscribed());
+    assertNull(subscriptionAttributesCustomSmsAttributesResponseModel.getUnsubscribed());
+    assertNull(subscriptionAttributesCustomSmsAttributesResponseModel.getInvited());
   }
 }

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesCustomSMSAttributesTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionCreateAttributesCustomSMSAttributesTest.java
@@ -1,0 +1,50 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
+
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionCreateAttributesCustomSMSAttributes;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the SubscriptionCreateAttributesCustomSMSAttributes model.
+ */
+public class SubscriptionCreateAttributesCustomSMSAttributesTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testSubscriptionCreateAttributesCustomSMSAttributes() throws Throwable {
+    SubscriptionCreateAttributesCustomSMSAttributes subscriptionCreateAttributesCustomSmsAttributesModel = new SubscriptionCreateAttributesCustomSMSAttributes.Builder()
+      .invited(java.util.Arrays.asList("testString"))
+      .build();
+    assertEquals(subscriptionCreateAttributesCustomSmsAttributesModel.invited(), java.util.Arrays.asList("testString"));
+
+    String json = TestUtilities.serialize(subscriptionCreateAttributesCustomSmsAttributesModel);
+
+    SubscriptionCreateAttributesCustomSMSAttributes subscriptionCreateAttributesCustomSmsAttributesModelNew = TestUtilities.deserialize(json, SubscriptionCreateAttributesCustomSMSAttributes.class);
+    assertTrue(subscriptionCreateAttributesCustomSmsAttributesModelNew instanceof SubscriptionCreateAttributesCustomSMSAttributes);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testSubscriptionCreateAttributesCustomSMSAttributesError() throws Throwable {
+    new SubscriptionCreateAttributesCustomSMSAttributes.Builder().build();
+  }
+
+}

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributesCustomSMSUpdateAttributesTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/SubscriptionUpdateAttributesCustomSMSUpdateAttributesTest.java
@@ -1,0 +1,71 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.eventnotifications.event_notifications.v1.model;
+
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.SubscriptionUpdateAttributesCustomSMSUpdateAttributes;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.UpdateAttributesInvited;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.UpdateAttributesSubscribed;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.model.UpdateAttributesUnsubscribed;
+import com.ibm.cloud.eventnotifications.event_notifications.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the SubscriptionUpdateAttributesCustomSMSUpdateAttributes model.
+ */
+public class SubscriptionUpdateAttributesCustomSMSUpdateAttributesTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testSubscriptionUpdateAttributesCustomSMSUpdateAttributes() throws Throwable {
+    UpdateAttributesInvited updateAttributesInvitedModel = new UpdateAttributesInvited.Builder()
+      .add(java.util.Arrays.asList("testString"))
+      .remove(java.util.Arrays.asList("testString"))
+      .build();
+    assertEquals(updateAttributesInvitedModel.add(), java.util.Arrays.asList("testString"));
+    assertEquals(updateAttributesInvitedModel.remove(), java.util.Arrays.asList("testString"));
+
+    UpdateAttributesSubscribed updateAttributesSubscribedModel = new UpdateAttributesSubscribed.Builder()
+      .remove(java.util.Arrays.asList("testString"))
+      .build();
+    assertEquals(updateAttributesSubscribedModel.remove(), java.util.Arrays.asList("testString"));
+
+    UpdateAttributesUnsubscribed updateAttributesUnsubscribedModel = new UpdateAttributesUnsubscribed.Builder()
+      .remove(java.util.Arrays.asList("testString"))
+      .build();
+    assertEquals(updateAttributesUnsubscribedModel.remove(), java.util.Arrays.asList("testString"));
+
+    SubscriptionUpdateAttributesCustomSMSUpdateAttributes subscriptionUpdateAttributesCustomSmsUpdateAttributesModel = new SubscriptionUpdateAttributesCustomSMSUpdateAttributes.Builder()
+      .invited(updateAttributesInvitedModel)
+      .subscribed(updateAttributesSubscribedModel)
+      .unsubscribed(updateAttributesUnsubscribedModel)
+      .build();
+    assertEquals(subscriptionUpdateAttributesCustomSmsUpdateAttributesModel.invited(), updateAttributesInvitedModel);
+    assertEquals(subscriptionUpdateAttributesCustomSmsUpdateAttributesModel.subscribed(), updateAttributesSubscribedModel);
+    assertEquals(subscriptionUpdateAttributesCustomSmsUpdateAttributesModel.unsubscribed(), updateAttributesUnsubscribedModel);
+
+    String json = TestUtilities.serialize(subscriptionUpdateAttributesCustomSmsUpdateAttributesModel);
+
+    SubscriptionUpdateAttributesCustomSMSUpdateAttributes subscriptionUpdateAttributesCustomSmsUpdateAttributesModelNew = TestUtilities.deserialize(json, SubscriptionUpdateAttributesCustomSMSUpdateAttributes.class);
+    assertTrue(subscriptionUpdateAttributesCustomSmsUpdateAttributesModelNew instanceof SubscriptionUpdateAttributesCustomSMSUpdateAttributes);
+    assertEquals(subscriptionUpdateAttributesCustomSmsUpdateAttributesModelNew.invited().toString(), updateAttributesInvitedModel.toString());
+    assertEquals(subscriptionUpdateAttributesCustomSmsUpdateAttributesModelNew.subscribed().toString(), updateAttributesSubscribedModel.toString());
+    assertEquals(subscriptionUpdateAttributesCustomSmsUpdateAttributesModelNew.unsubscribed().toString(), updateAttributesUnsubscribedModel.toString());
+  }
+}

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/UpdateDestinationOptionsTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/UpdateDestinationOptionsTest.java
@@ -73,6 +73,7 @@ public class UpdateDestinationOptionsTest {
       .id("testString")
       .name("testString")
       .description("testString")
+      .collectFailedEvents(false)
       .config(destinationConfigModel)
       .certificate(TestUtilities.createMockStream("This is a mock file."))
       .certificateContentType("testString")
@@ -93,6 +94,7 @@ public class UpdateDestinationOptionsTest {
     assertEquals(updateDestinationOptionsModel.id(), "testString");
     assertEquals(updateDestinationOptionsModel.name(), "testString");
     assertEquals(updateDestinationOptionsModel.description(), "testString");
+    assertEquals(updateDestinationOptionsModel.collectFailedEvents(), Boolean.valueOf(false));
     assertEquals(updateDestinationOptionsModel.config(), destinationConfigModel);
     assertEquals(IOUtils.toString(updateDestinationOptionsModel.certificate()), IOUtils.toString(TestUtilities.createMockStream("This is a mock file.")));
     assertEquals(updateDestinationOptionsModel.certificateContentType(), "testString");

--- a/modules/examples/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsExamples.java
+++ b/modules/examples/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsExamples.java
@@ -1619,7 +1619,7 @@ public class EventNotificationsExamples {
               .subject("Hi this is invitation for invitation message")
               .build();
 
-      ReplaceTemplateOptions updateTemplateInvitationOptions = new ReplaceTemplateOptions.Builder()
+      ReplaceTemplateOptions replaceTemplateInvitationOptions = new ReplaceTemplateOptions.Builder()
               .instanceId(instanceId)
               .id(templateInvitationID)
               .name(name)
@@ -1628,12 +1628,12 @@ public class EventNotificationsExamples {
               .params(templateConfig)
               .build();
 
-      Response<Template> invitationResponse = eventNotificationsService.replaceTemplate(updateTemplateInvitationOptions).execute();
+      Response<Template> invitationResponse = eventNotificationsService.replaceTemplate(replaceTemplateInvitationOptions).execute();
 
       Template invitationTemplateResult = invitationResponse.getResult();
       System.out.println(invitationTemplateResult);
 
-      ReplaceTemplateOptions updateTemplateNotificationOptions = new ReplaceTemplateOptions.Builder()
+      ReplaceTemplateOptions replaceTemplateNotificationOptions = new ReplaceTemplateOptions.Builder()
               .instanceId(instanceId)
               .id(templateNotificationID)
               .name(name)
@@ -1642,7 +1642,7 @@ public class EventNotificationsExamples {
               .params(templateConfig)
               .build();
 
-      Response<Template> notificationResponse = eventNotificationsService.replaceTemplate(updateTemplateNotificationOptions).execute();
+      Response<Template> notificationResponse = eventNotificationsService.replaceTemplate(replaceTemplateNotificationOptions).execute();
 
       Template notificationTemplateResult = notificationResponse.getResult();
       // end-update_template
@@ -1907,7 +1907,7 @@ public class EventNotificationsExamples {
 
     try {
       System.out.println("getEnabledCountries() result:");
-      // begin-enabled_countries
+      // begin-get_enabled_countries
       GetEnabledCountriesOptions getEnabledCountriesOptions = new GetEnabledCountriesOptions.Builder()
               .instanceId(instanceId)
               .id(destinationId17)
@@ -1917,8 +1917,7 @@ public class EventNotificationsExamples {
       Response<EnabledCountriesResponse> response = eventNotificationsService.getEnabledCountries(getEnabledCountriesOptions).execute();
       EnabledCountriesResponse enabledCountriesResult = response.getResult();
       System.out.println(enabledCountriesResult);
-
-      // end-enabled_countries
+      // end-get_enabled_countries
     } catch (ServiceResponseException e) {
       logger.error(String.format("Service returned status code %s: %s%nError details: %s",
               e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
@@ -2113,11 +2112,9 @@ public class EventNotificationsExamples {
               .metadata(metadata)
               .build();
 
-      // Invoke operation
       Response<IntegrationCreateResponse> response = eventNotificationsService.createIntegration(integrationsOptions).execute();
       cosIntegrationID = response.getResult().getId();
       // end-create_integrations
-
     } catch (ServiceResponseException e) {
       logger.error(String.format("Service returned status code %s: %s%nError details: %s",
               e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);

--- a/modules/examples/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsExamples.java
+++ b/modules/examples/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsExamples.java
@@ -65,6 +65,7 @@ public class EventNotificationsExamples {
   public static String destinationId14 = "";
   public static String destinationId15 = "";
   public static String destinationId16 = "";
+  public static String destinationId17 = "";
   public static String safariCertificatePath = "";
   public static String subscriptionId = "";
   public static String subscriptionId1 = "";
@@ -73,6 +74,7 @@ public class EventNotificationsExamples {
   public static String subscriptionId4 = "";
   public static String subscriptionId5 = "";
   public static String subscriptionId6 = "";
+  public static String subscriptionId7 = "";
   public static Map<String, String> config = null;
   public static String fcmServerKey = "";
   public static String fcmSenderId = "";
@@ -93,6 +95,9 @@ public class EventNotificationsExamples {
   public static String cosEndPoint = "";
   public static String templateInvitationID = "";
   public static String templateNotificationID = "";
+  public static String templateBody = "";
+  public static String cosIntegrationID = "";
+  public static String cosInstanceCRN = "";
 
   static String getConfigFilename() {
     return "./event_notifications_v1.env";
@@ -137,6 +142,8 @@ public class EventNotificationsExamples {
     cosBucketName = config.get("COS_BUCKET_NAME");
     cosEndPoint = config.get("COS_ENDPOINT");
     cosInstanceID = config.get("COS_INSTANCE");
+    templateBody = config.get("TEMPLATE_BODY");
+    cosInstanceCRN = config.get("COS_INSTANCE_CRN");
 
     try {
       System.out.println("createSources() result:");
@@ -755,6 +762,24 @@ public class EventNotificationsExamples {
       DestinationResponse destinationCustomResponseResult = customResponse.getResult();
       System.out.println(destinationCustomResponseResult);
       destinationId16 = destinationCustomResponseResult.getId();
+
+      String customSMSName = "Custom SMS";
+      String customSMSTypeVal = "sms_custom";
+      String customSMSDescription = "Custom SMS Destination";
+
+      CreateDestinationOptions createCustomSMSDestinationOptions = new CreateDestinationOptions.Builder()
+              .instanceId(instanceId)
+              .name(customSMSName)
+              .type(customSMSTypeVal)
+              .collectFailedEvents(false)
+              .description(customSMSDescription)
+              .build();
+
+      Response<DestinationResponse> customSMSResponse = eventNotificationsService.createDestination(createCustomSMSDestinationOptions).execute();
+      DestinationResponse destinationCustomSMSResponseResult = customSMSResponse.getResult();
+      System.out.println(destinationCustomSMSResponseResult);
+      destinationId17 = destinationCustomSMSResponseResult.getId();
+
       // end-create_destination
 
     } catch (ServiceResponseException e) {
@@ -1260,6 +1285,22 @@ public class EventNotificationsExamples {
       Response<VerificationResponse> dkimVerificationResponse = eventNotificationsService.updateVerifyDestination(updateDkimVerifyDestinationOptionsModel).execute();
       VerificationResponse dkimResponseObj = dkimVerificationResponse.getResult();
       System.out.println(dkimResponseObj);
+
+      String customSMSName = "Custom SMS update";
+      String customSMSDescription = "Custom SMS Destination update";
+
+      UpdateDestinationOptions updateCustomSMSDestinationOptions = new UpdateDestinationOptions.Builder()
+              .instanceId(instanceId)
+              .name(customSMSName)
+              .id(destinationId17)
+              .collectFailedEvents(false)
+              .description(customSMSDescription)
+              .build();
+
+      Response<Destination> customSMSResponse = eventNotificationsService.updateDestination(updateCustomSMSDestinationOptions).execute();
+      Destination destinationCustomSMSResponseResult = customSMSResponse.getResult();
+      System.out.println(destinationCustomSMSResponseResult);
+
       // end-update_destination
     } catch (ServiceResponseException e) {
       logger.error(String.format("Service returned status code %s: %s%nError details: %s",
@@ -1273,7 +1314,7 @@ public class EventNotificationsExamples {
       String description = "template description";
 
       TemplateConfig templateConfig = new TemplateConfig.Builder()
-              .body("<!DOCTYPE html><html><head><title>IBM Event Notifications</title></head><body><p>Hello! Invitation template</p><table><tr><td>Hello invitation link:{{ ibmen_invitation }} </td></tr></table></body></html>")
+              .body(templateBody)
               .subject("Hi this is invitation for invitation message")
               .build();
 
@@ -1471,6 +1512,30 @@ public class EventNotificationsExamples {
       Response<Subscription> customResponse = eventNotificationsService.createSubscription(createCustomSubscriptionOptions).execute();
       Subscription customSubscriptionResult = customResponse.getResult();
       subscriptionId6 = customSubscriptionResult.getId();
+
+      ArrayList<String> customToNumber = new ArrayList<String>();
+      customToNumber.add("+911234567890");
+      customToNumber.add("+12267054625");
+      SubscriptionCreateAttributesCustomSMSAttributes subscriptionCreateCustomSMSAttributesModel = new SubscriptionCreateAttributesCustomSMSAttributes.Builder()
+              .invited(customToNumber)
+              .build();
+
+      String customSMSName = "subscription_custom_sms";
+      String customSMSDescription = "Subscription custom sms";
+
+      CreateSubscriptionOptions createCustomSMSSubscriptionOptions = new CreateSubscriptionOptions.Builder()
+              .instanceId(instanceId)
+              .name(customSMSName)
+              .destinationId(destinationId17)
+              .topicId(topicId)
+              .attributes(subscriptionCreateCustomSMSAttributesModel)
+              .description(customSMSDescription)
+              .build();
+
+      Response<Subscription> customSMSResponse = eventNotificationsService.createSubscription(createCustomSMSSubscriptionOptions).execute();
+      Subscription customSMSSubscriptionResult = customSMSResponse.getResult();
+      subscriptionId7 = customSMSSubscriptionResult.getId();
+
       // end-create_subscription
 
     } catch (ServiceResponseException e) {
@@ -1550,11 +1615,11 @@ public class EventNotificationsExamples {
       String description = "template description";
 
       TemplateConfig templateConfig = new TemplateConfig.Builder()
-              .body("<!DOCTYPE html><html><head><title>IBM Event Notifications</title></head><body><p>Hello! Invitation template</p><table><tr><td>Hello invitation link:{{ ibmen_invitation }} </td></tr></table></body></html>")
+              .body(templateBody)
               .subject("Hi this is invitation for invitation message")
               .build();
 
-      UpdateTemplateOptions updateTemplateInvitationOptions = new UpdateTemplateOptions.Builder()
+      ReplaceTemplateOptions updateTemplateInvitationOptions = new ReplaceTemplateOptions.Builder()
               .instanceId(instanceId)
               .id(templateInvitationID)
               .name(name)
@@ -1563,12 +1628,12 @@ public class EventNotificationsExamples {
               .params(templateConfig)
               .build();
 
-      Response<Template> invitationResponse = eventNotificationsService.updateTemplate(updateTemplateInvitationOptions).execute();
+      Response<Template> invitationResponse = eventNotificationsService.replaceTemplate(updateTemplateInvitationOptions).execute();
 
       Template invitationTemplateResult = invitationResponse.getResult();
       System.out.println(invitationTemplateResult);
 
-      UpdateTemplateOptions updateTemplateNotificationOptions = new UpdateTemplateOptions.Builder()
+      ReplaceTemplateOptions updateTemplateNotificationOptions = new ReplaceTemplateOptions.Builder()
               .instanceId(instanceId)
               .id(templateNotificationID)
               .name(name)
@@ -1577,7 +1642,7 @@ public class EventNotificationsExamples {
               .params(templateConfig)
               .build();
 
-      Response<Template> notificationResponse = eventNotificationsService.updateTemplate(updateTemplateNotificationOptions).execute();
+      Response<Template> notificationResponse = eventNotificationsService.replaceTemplate(updateTemplateNotificationOptions).execute();
 
       Template notificationTemplateResult = notificationResponse.getResult();
       // end-update_template
@@ -1795,7 +1860,65 @@ public class EventNotificationsExamples {
       Subscription customEmailSubscriptionResult = customEmailResponse.getResult();
       System.out.println(customEmailSubscriptionResult);
 
+      ArrayList<String> toCustomPhRemove = new ArrayList<String>();
+      toCustomPhRemove.add("+12064512559");
+
+      ArrayList<String> toCustomPhInvite = new ArrayList<String>();
+      toCustomPhInvite.add("+12064512559");
+
+      UpdateAttributesSubscribed customPhSubscribed = new UpdateAttributesSubscribed.Builder()
+              .remove(toCustomPhRemove)
+              .build();
+
+      UpdateAttributesUnsubscribed customPhUnSubscribed = new UpdateAttributesUnsubscribed.Builder()
+              .remove(toCustomPhRemove)
+              .build();
+
+      UpdateAttributesInvited customPhInvited = new UpdateAttributesInvited.Builder()
+              .add(toCustomPhInvite)
+              .build();
+
+      SubscriptionUpdateAttributesCustomSMSUpdateAttributes subscriptionUpdateCustomSMSAttributesModel = new SubscriptionUpdateAttributesCustomSMSUpdateAttributes.Builder()
+              .invited(customPhInvited)
+              .subscribed(customPhSubscribed)
+              .unsubscribed(customPhUnSubscribed)
+              .build();
+
+      String customSMSName = "custom sms subscription update";
+      String customSMSDescription = "custom subscription_update for sms";
+
+      UpdateSubscriptionOptions customSMSUpdateSubscriptionOptions = new UpdateSubscriptionOptions.Builder()
+              .instanceId(instanceId)
+              .name(customSMSName)
+              .id(subscriptionId7)
+              .attributes(subscriptionUpdateCustomSMSAttributesModel)
+              .description(customSMSDescription)
+              .build();
+
+      Response<Subscription> customSMSResponse = eventNotificationsService.updateSubscription(customSMSUpdateSubscriptionOptions).execute();
+      Subscription customSMSSubscriptionResult = customSMSResponse.getResult();
+      System.out.println(customSMSSubscriptionResult);
+
       // end-update_subscription
+    } catch (ServiceResponseException e) {
+      logger.error(String.format("Service returned status code %s: %s%nError details: %s",
+              e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+    }
+
+    try {
+      System.out.println("getEnabledCountries() result:");
+      // begin-enabled_countries
+      GetEnabledCountriesOptions getEnabledCountriesOptions = new GetEnabledCountriesOptions.Builder()
+              .instanceId(instanceId)
+              .id(destinationId17)
+              .build();
+
+      // Invoke operation
+      Response<EnabledCountriesResponse> response = eventNotificationsService.getEnabledCountries(getEnabledCountriesOptions).execute();
+      EnabledCountriesResponse enabledCountriesResult = response.getResult();
+      System.out.println(enabledCountriesResult);
+
+      // end-enabled_countries
     } catch (ServiceResponseException e) {
       logger.error(String.format("Service returned status code %s: %s%nError details: %s",
               e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
@@ -1810,6 +1933,7 @@ public class EventNotificationsExamples {
       String safariJsonString = "{\"aps\":{\"alert\":{\"title\":\"FlightA998NowBoarding\",\"body\":\"BoardinghasbegunforFlightA998.\",\"action\":\"View\"},\"url-args\":[\"boarding\",\"A998\"]}}";
       String huaweiJsonString = "{\"message\":{\"android\":{\"notification\":{\"title\":\"New Message\",\"body\":\"Hello World\",\"click_action\":{\"type\":3}}}}}";
       String mailTo = "[\"abc@ibm.com\", \"def@us.ibm.com\"]";
+      String smsTo = "[\"+911234567890\", \"+911224567890\"]";
       String htmlBody = "\"Hi  ,<br/>Certificate expiring in 90 days.<br/><br/>Please login to <a href=\"https: //cloud.ibm.com/security-compliance/dashboard\">Security and Complaince dashboard</a> to find more information<br/>\"";
 
       NotificationCreate body = new NotificationCreate.Builder()
@@ -1823,6 +1947,7 @@ public class EventNotificationsExamples {
               .ibmenpushto(notificationDevices)
               .ibmensubject("certificate expires")
               .ibmenmailto(mailTo)
+              .ibmensmsto(smsTo)
               .ibmenhtmlbody(htmlBody)
               .ibmenfcmbody(fcmJsonString)
               .ibmenapnsbody(apnsJsonString)
@@ -1882,6 +2007,7 @@ public class EventNotificationsExamples {
       subscriptions.add(subscriptionId4);
       subscriptions.add(subscriptionId5);
       subscriptions.add(subscriptionId6);
+      subscriptions.add(subscriptionId7);
 
       for (String subscription : subscriptions) {
         deleteSubscriptionOptions = new DeleteSubscriptionOptions.Builder()
@@ -1940,6 +2066,7 @@ public class EventNotificationsExamples {
       destinations.add(destinationId14);
       destinations.add(destinationId15);
       destinations.add(destinationId16);
+      destinations.add(destinationId17);
 
       for (String destination : destinations) {
         deleteDestinationOptions = new DeleteDestinationOptions.Builder()
@@ -1967,6 +2094,30 @@ public class EventNotificationsExamples {
       Response<Void> response = eventNotificationsService.deleteSource(deleteSourceOptions).execute();
       // end-delete_source
       System.out.printf("deleteSource() response status code: %d%n", response.getStatusCode());
+    } catch (ServiceResponseException e) {
+      logger.error(String.format("Service returned status code %s: %s%nError details: %s",
+              e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+    }
+
+    try {
+      // begin-create_integrations
+      IntegrationCreateMetadata metadata = new IntegrationCreateMetadata.Builder()
+              .endpoint(cosEndPoint)
+              .crn(cosInstanceCRN)
+              .bucketName(cosBucketName)
+              .build();
+
+      CreateIntegrationOptions integrationsOptions = new CreateIntegrationOptions.Builder()
+              .instanceId(instanceId)
+              .type("collect_failed_events")
+              .metadata(metadata)
+              .build();
+
+      // Invoke operation
+      Response<IntegrationCreateResponse> response = eventNotificationsService.createIntegration(integrationsOptions).execute();
+      cosIntegrationID = response.getResult().getId();
+      // end-create_integrations
+
     } catch (ServiceResponseException e) {
       logger.error(String.format("Service returned status code %s: %s%nError details: %s",
               e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
@@ -2026,6 +2177,23 @@ public class EventNotificationsExamples {
 
       // Invoke operation
       Response<IntegrationGetResponse> response = eventNotificationsService.replaceIntegration(integrationsOptions).execute();
+
+      // COS Integration
+      IntegrationMetadata cosMetadata = new IntegrationMetadata.Builder()
+              .endpoint(cosEndPoint)
+              .crn(cosInstanceCRN)
+              .bucketName(cosBucketName)
+              .build();
+
+      ReplaceIntegrationOptions cfeIntegrationsOptions = new ReplaceIntegrationOptions.Builder()
+              .instanceId(instanceId)
+              .id(cosIntegrationID)
+              .type("collect_failed_events")
+              .metadata(cosMetadata)
+              .build();
+
+      // Invoke operation
+      Response<IntegrationGetResponse> cfeResponse = eventNotificationsService.replaceIntegration(cfeIntegrationsOptions).execute();
       // end-replace_integration
       System.out.printf("updateIntegration() response status code: %d%n", response.getStatusCode());
     } catch (ServiceResponseException e) {


### PR DESCRIPTION
## PR summary

changes include api changes of

Collect failed events
Integration create api
Custom sms
enabled Countries get api
updatetemplate is replace to ReplaceTemplate (breaking change)

**Fixes:** 

https://github.ibm.com/Notification-Hub/planning/issues/10707
https://github.ibm.com/Notification-Hub/planning/issues/10954
https://github.ibm.com/Notification-Hub/planning/issues/11152

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  

SDK was not having below mentioned API changes

Collect failed events
Integration create api
Custom sms
enabled Countries get api
updatetemplate is replace to ReplaceTemplate

## What is the new behavior?  

Provided support for below mentioned API

Collect failed events
Integration create api
Custom sms
enabled Countries get api
updatetemplate is replace to ReplaceTemplate

## Does this PR introduce a breaking change?    
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->