### PR TITLE
chore: making api_key as deprecated for pagerduty destination

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-02-25T18:26:11Z",
+  "generated_at": "2025-04-21T04:10:36Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -136,7 +136,7 @@
         "hashed_secret": "9bf92274d58c3655b80055ad2ab17540f71d3058",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3084,
+        "line_number": 3089,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/README.md
+++ b/README.md
@@ -1324,6 +1324,17 @@ If you encounter an issue with the project, you are welcome to submit a
 [bug report](https://github.com/IBM/event-notifications-java-admin-sdk/issues).
 Before that, please search for similar issues. It's possible that someone has already reported the problem.
 
+## ⚠️ Deprecation Notice (Attributes)
+
+### Pagerduty Destination Configuration
+
+> The following attribute from DestinationConfigOneOfPagerDutyDestinationConfig.java
+is **deprecated** and will be removed in a future release:
+
+- `apikey`
+
+This attribute no longer recommended for use and may not be supported in upcoming versions of the SDK. Only `routingKey` is expected to be passed.
+
 ## Open source @ IBM
 
 Find more open source projects on the [IBM Github Page](http://ibm.github.io/)

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOf.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOf.java
@@ -533,7 +533,7 @@ public class DestinationConfigOneOf extends GenericModel {
   /**
    * Gets the endpoint.
    *
-   * End Point of Cloud Object Storage.
+   * Endpoint of Cloud Object Storage.
    *
    * @return the endpoint
    */

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfPagerDutyDestinationConfig.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/DestinationConfigOneOfPagerDutyDestinationConfig.java
@@ -44,11 +44,9 @@ public class DestinationConfigOneOfPagerDutyDestinationConfig extends Destinatio
     /**
      * Instantiates a new builder with required properties.
      *
-     * @param apiKey the apiKey
      * @param routingKey the routingKey
      */
-    public Builder(String apiKey, String routingKey) {
-      this.apiKey = apiKey;
+    public Builder(String routingKey) {
       this.routingKey = routingKey;
     }
 
@@ -66,7 +64,9 @@ public class DestinationConfigOneOfPagerDutyDestinationConfig extends Destinatio
      *
      * @param apiKey the apiKey
      * @return the DestinationConfigOneOfPagerDutyDestinationConfig builder
+     * @deprecated this method is deprecated and may be removed in a future release
      */
+    @Deprecated
     public Builder apiKey(String apiKey) {
       this.apiKey = apiKey;
       return this;
@@ -87,8 +87,6 @@ public class DestinationConfigOneOfPagerDutyDestinationConfig extends Destinatio
   protected DestinationConfigOneOfPagerDutyDestinationConfig() { }
 
   protected DestinationConfigOneOfPagerDutyDestinationConfig(Builder builder) {
-    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.apiKey,
-      "apiKey cannot be null");
     com.ibm.cloud.sdk.core.util.Validator.notNull(builder.routingKey,
       "routingKey cannot be null");
     apiKey = builder.apiKey;


### PR DESCRIPTION
## PR summary
making api_key as deprecated for pagerduty destination

**Fixes:** 
https://github.ibm.com/Notification-Hub/planning/issues/17816

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
pagerduty destination configuration requires property api_key

## What is the new behavior?  
 api_key is depracated for pagerduty destination. only requires routing_key

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->