### PR TITLE
fix: adding the smtp config id for metrics api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://app.travis-ci.com/IBM/event-notifications-java-admin-sdk.svg?branch=main)](https://travis-ci.com/IBM/event-notifications-java-admin-sdk)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-# Java server SDK for IBM Cloud Event Notifications service Version 0.24.0
+# Java server SDK for IBM Cloud Event Notifications service Version 0.24.1
 
 Java client library to interact with various [IBM Cloud Event Notifications Service](https://cloud.ibm.com/apidocs?category=event-notifications).
 
@@ -27,7 +27,7 @@ The IBM Cloud Event Notifications Service Java SDK allows developers to programm
 
 | Service Name                                                                     | Artifact Coordinates                     |
 | -------------------------------------------------------------------------------- |------------------------------------------|
-| [Event Notifications Service](https://cloud.ibm.com/apidocs/event-notifications) | com.ibm.cloud:event-notifications:0.24.0 |
+| [Event Notifications Service](https://cloud.ibm.com/apidocs/event-notifications) | com.ibm.cloud:event-notifications:0.24.1 |
 
 ## Prerequisites
 
@@ -40,7 +40,7 @@ The IBM Cloud Event Notifications Service Java SDK allows developers to programm
 
 ## Installation
 
-The current version of this SDK is: 0.24.0
+The current version of this SDK is: 0.24.1
 
 Each service's artifact coordinates are listed in the table above.
 
@@ -57,14 +57,14 @@ To use the Event Notifications Java SDK, define a dependency that contains the a
 <dependency>
     <groupId>com.ibm.cloud</groupId>
     <artifactId>event-notifications</artifactId>
-    <version>0.24.0</version>
+    <version>0.24.1</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```gradle
-compile 'com.ibm.cloud:event-notifications:0.24.0'
+compile 'com.ibm.cloud:event-notifications:0.24.1'
 ```
 
 ## Using the SDK
@@ -169,8 +169,10 @@ SDK Methods to consume
   - [Delete SMTP Configuration](#delete-smtp-user)
   - [Verify SMTP](#verify-smtp)
 - [Metrics](#Metrics)
-  - [Get Metrics](#get-metrics)
-  - [Get Bounce Metrics](#get-bounce-metrics)
+  - [Get Metrics With Destination Type](#get-metrics)
+  - [Get Metrics With SMTP Config ID](#get-metrics)
+  - [Get Bounce Metrics With Destination Type](#get-bounce-metrics)
+  - [Get Bounce Metrics With SMTP Config ID](#get-bounce-metrics)
 - [Send Notifications](#send-notifications)
 
 ## Source
@@ -1452,8 +1454,8 @@ System.out.println(response);
 
 ```java
 DeleteSmtpConfigurationOptions deleteSmtpConfigurationOptionsModel = new DeleteSmtpConfigurationOptions.Builder()
-        .instanceId(instanceId)
-        .id(smtpConfigID)
+        .instanceId(<instanceId>)
+        .id(<smtpConfigID>)
         .build();
 
 Response<Void> response = eventNotificationsService.deleteSmtpConfiguration(deleteSmtpConfigurationOptionsModel).execute();
@@ -1464,8 +1466,8 @@ System.out.println(response);
 
 ```java
 UpdateVerifySmtpOptions updateVerifySmtpOptions = new UpdateVerifySmtpOptions.Builder()
-        .instanceId(instanceId)
-        .id(smtpConfigID)
+        .instanceId(<instanceId>)
+        .id(<smtpConfigID>)
         .type("dkim,spf,en_authorization")
         .build();
 
@@ -1475,11 +1477,11 @@ SMTPVerificationUpdateResponse updateVerifySmtpResponse = response.getResult();
 
 ## Metrics
 
-### Get Metrics
+### Get Metrics With Destination Type
 
 ```java
 GetMetricsOptions getMetricsOptionsModel = new GetMetricsOptions.Builder()
-        .instanceId(instanceId)
+        .instanceId(<instanceId>)
         .destinationType("smtp_custom")
         .gte(<gte-timestamp>)
         .lte(<lte-timestamp>)
@@ -1496,15 +1498,54 @@ Response<Metrics> response = eventNotificationsService.getMetrics(getMetricsOpti
 Metrics responseObj = response.getResult();
 ```
 
-### Get Bounce Metrics
+### Get Metrics With SMTP Config ID
+
+```java
+GetMetricsOptions getMetricsOptionsModel = new GetMetricsOptions.Builder()
+        .instanceId(<instanceId>)
+        .smtpConfigId(<smtpConfigID>)
+        .gte(<gte-timestamp>)
+        .lte(<lte-timestamp>)
+        .subscriptionId(<subscription-id>)
+        .emailTo(<email-to>)
+        .sourceId(<source-id>)
+        .notificationId(<notification-id>)
+        .subject(<subject>)
+        .build();
+
+        // Invoke getMetrics() with a valid options model and verify the result
+Response<Metrics> response = eventNotificationsService.getMetrics(getMetricsOptionsModel).execute();
+Metrics responseObj = response.getResult();
+```
+
+### Get Bounce Metrics With Destination Type
 
 ```java
 GetBounceMetricsOptions getBounceMetricsOptionsModel = new GetBounceMetricsOptions.Builder()
-        .instanceId(instanceId)
+        .instanceId(<instanceId>)
         .destinationType("smtp_custom")
         .gte(<gte-timestamp>)
         .lte(<lte-timestamp>)
         .destinationId(<destination-id>)
+        .subscriptionId(<subscription-id>)
+        .emailTo(<email-to>)
+        .sourceId(<source-id>)
+        .notificationId(<notification-id>)
+        .subject(<subject>)
+        .build();
+
+Response<BounceMetrics> response = eventNotificationsService.getBounceMetrics(getBounceMetricsOptionsModel).execute();
+BounceMetrics responseObj = response.getResult();
+```
+
+### Get Bounce Metrics With SMTP Config ID
+
+```java
+GetBounceMetricsOptions getBounceMetricsOptionsModel = new GetBounceMetricsOptions.Builder()
+        .instanceId(<instanceId>)
+        .smtpConfigId(<smtpConfigID>)
+        .gte(<gte-timestamp>)
+        .lte(<lte-timestamp>)
         .subscriptionId(<subscription-id>)
         .emailTo(<email-to>)
         .sourceId(<source-id>)

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotifications.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotifications.java
@@ -194,9 +194,14 @@ public class EventNotifications extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
-    builder.query("destination_type", String.valueOf(getMetricsOptions.destinationType()));
     builder.query("gte", String.valueOf(getMetricsOptions.gte()));
     builder.query("lte", String.valueOf(getMetricsOptions.lte()));
+    if (getMetricsOptions.smtpConfigId() != null) {
+      builder.query("smtp_config_id", String.valueOf(getMetricsOptions.smtpConfigId()));
+    }
+    if (getMetricsOptions.destinationType() != null) {
+      builder.query("destination_type", String.valueOf(getMetricsOptions.destinationType()));
+    }
     if (getMetricsOptions.destinationId() != null) {
       builder.query("destination_id", String.valueOf(getMetricsOptions.destinationId()));
     }
@@ -239,9 +244,14 @@ public class EventNotifications extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
-    builder.query("destination_type", String.valueOf(getBounceMetricsOptions.destinationType()));
     builder.query("gte", String.valueOf(getBounceMetricsOptions.gte()));
     builder.query("lte", String.valueOf(getBounceMetricsOptions.lte()));
+    if (getBounceMetricsOptions.smtpConfigId() != null) {
+      builder.query("smtp_config_id", String.valueOf(getBounceMetricsOptions.smtpConfigId()));
+    }
+    if (getBounceMetricsOptions.destinationType() != null) {
+      builder.query("destination_type", String.valueOf(getBounceMetricsOptions.destinationType()));
+    }
     if (getBounceMetricsOptions.destinationId() != null) {
       builder.query("destination_id", String.valueOf(getBounceMetricsOptions.destinationId()));
     }

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetBounceMetricsOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetBounceMetricsOptions.java
@@ -20,7 +20,8 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
 public class GetBounceMetricsOptions extends GenericModel {
 
   /**
-   * Destination type. Allowed values are [smtp_custom].
+   * Destination type for which metrics are requested. Supported value: smtp_custom. Required when querying metrics for
+   * custom email destinations.
    */
   public interface DestinationType {
     /** smtp_custom. */
@@ -28,9 +29,10 @@ public class GetBounceMetricsOptions extends GenericModel {
   }
 
   protected String instanceId;
-  protected String destinationType;
   protected String gte;
   protected String lte;
+  protected String smtpConfigId;
+  protected String destinationType;
   protected String destinationId;
   protected String subscriptionId;
   protected String sourceId;
@@ -45,9 +47,10 @@ public class GetBounceMetricsOptions extends GenericModel {
    */
   public static class Builder {
     private String instanceId;
-    private String destinationType;
     private String gte;
     private String lte;
+    private String smtpConfigId;
+    private String destinationType;
     private String destinationId;
     private String subscriptionId;
     private String sourceId;
@@ -64,9 +67,10 @@ public class GetBounceMetricsOptions extends GenericModel {
      */
     private Builder(GetBounceMetricsOptions getBounceMetricsOptions) {
       this.instanceId = getBounceMetricsOptions.instanceId;
-      this.destinationType = getBounceMetricsOptions.destinationType;
       this.gte = getBounceMetricsOptions.gte;
       this.lte = getBounceMetricsOptions.lte;
+      this.smtpConfigId = getBounceMetricsOptions.smtpConfigId;
+      this.destinationType = getBounceMetricsOptions.destinationType;
       this.destinationId = getBounceMetricsOptions.destinationId;
       this.subscriptionId = getBounceMetricsOptions.subscriptionId;
       this.sourceId = getBounceMetricsOptions.sourceId;
@@ -87,13 +91,11 @@ public class GetBounceMetricsOptions extends GenericModel {
      * Instantiates a new builder with required properties.
      *
      * @param instanceId the instanceId
-     * @param destinationType the destinationType
      * @param gte the gte
      * @param lte the lte
      */
-    public Builder(String instanceId, String destinationType, String gte, String lte) {
+    public Builder(String instanceId, String gte, String lte) {
       this.instanceId = instanceId;
-      this.destinationType = destinationType;
       this.gte = gte;
       this.lte = lte;
     }
@@ -119,17 +121,6 @@ public class GetBounceMetricsOptions extends GenericModel {
     }
 
     /**
-     * Set the destinationType.
-     *
-     * @param destinationType the destinationType
-     * @return the GetBounceMetricsOptions builder
-     */
-    public Builder destinationType(String destinationType) {
-      this.destinationType = destinationType;
-      return this;
-    }
-
-    /**
      * Set the gte.
      *
      * @param gte the gte
@@ -148,6 +139,28 @@ public class GetBounceMetricsOptions extends GenericModel {
      */
     public Builder lte(String lte) {
       this.lte = lte;
+      return this;
+    }
+
+    /**
+     * Set the smtpConfigId.
+     *
+     * @param smtpConfigId the smtpConfigId
+     * @return the GetBounceMetricsOptions builder
+     */
+    public Builder smtpConfigId(String smtpConfigId) {
+      this.smtpConfigId = smtpConfigId;
+      return this;
+    }
+
+    /**
+     * Set the destinationType.
+     *
+     * @param destinationType the destinationType
+     * @return the GetBounceMetricsOptions builder
+     */
+    public Builder destinationType(String destinationType) {
+      this.destinationType = destinationType;
       return this;
     }
 
@@ -245,16 +258,15 @@ public class GetBounceMetricsOptions extends GenericModel {
   protected GetBounceMetricsOptions(Builder builder) {
     com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.instanceId,
       "instanceId cannot be empty");
-    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.destinationType,
-      "destinationType cannot be null");
     com.ibm.cloud.sdk.core.util.Validator.notNull(builder.gte,
       "gte cannot be null");
     com.ibm.cloud.sdk.core.util.Validator.notNull(builder.lte,
       "lte cannot be null");
     instanceId = builder.instanceId;
-    destinationType = builder.destinationType;
     gte = builder.gte;
     lte = builder.lte;
+    smtpConfigId = builder.smtpConfigId;
+    destinationType = builder.destinationType;
     destinationId = builder.destinationId;
     subscriptionId = builder.subscriptionId;
     sourceId = builder.sourceId;
@@ -286,17 +298,6 @@ public class GetBounceMetricsOptions extends GenericModel {
   }
 
   /**
-   * Gets the destinationType.
-   *
-   * Destination type. Allowed values are [smtp_custom].
-   *
-   * @return the destinationType
-   */
-  public String destinationType() {
-    return destinationType;
-  }
-
-  /**
    * Gets the gte.
    *
    * GTE (greater than equal), start timestamp in UTC.
@@ -316,6 +317,29 @@ public class GetBounceMetricsOptions extends GenericModel {
    */
   public String lte() {
     return lte;
+  }
+
+  /**
+   * Gets the smtpConfigId.
+   *
+   * SMTP configuration ID. Required when querying metrics for SMTP interface destinations.
+   *
+   * @return the smtpConfigId
+   */
+  public String smtpConfigId() {
+    return smtpConfigId;
+  }
+
+  /**
+   * Gets the destinationType.
+   *
+   * Destination type for which metrics are requested. Supported value: smtp_custom. Required when querying metrics for
+   * custom email destinations.
+   *
+   * @return the destinationType
+   */
+  public String destinationType() {
+    return destinationType;
   }
 
   /**

--- a/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetMetricsOptions.java
+++ b/modules/event-notifications/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetMetricsOptions.java
@@ -20,7 +20,8 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
 public class GetMetricsOptions extends GenericModel {
 
   /**
-   * Destination type. Allowed values are [smtp_custom].
+   * Destination type for which metrics are requested. Supported value: smtp_custom. Required when querying metrics for
+   * custom email destinations.
    */
   public interface DestinationType {
     /** smtp_custom. */
@@ -28,9 +29,10 @@ public class GetMetricsOptions extends GenericModel {
   }
 
   protected String instanceId;
-  protected String destinationType;
   protected String gte;
   protected String lte;
+  protected String smtpConfigId;
+  protected String destinationType;
   protected String destinationId;
   protected String subscriptionId;
   protected String sourceId;
@@ -43,9 +45,10 @@ public class GetMetricsOptions extends GenericModel {
    */
   public static class Builder {
     private String instanceId;
-    private String destinationType;
     private String gte;
     private String lte;
+    private String smtpConfigId;
+    private String destinationType;
     private String destinationId;
     private String subscriptionId;
     private String sourceId;
@@ -60,9 +63,10 @@ public class GetMetricsOptions extends GenericModel {
      */
     private Builder(GetMetricsOptions getMetricsOptions) {
       this.instanceId = getMetricsOptions.instanceId;
-      this.destinationType = getMetricsOptions.destinationType;
       this.gte = getMetricsOptions.gte;
       this.lte = getMetricsOptions.lte;
+      this.smtpConfigId = getMetricsOptions.smtpConfigId;
+      this.destinationType = getMetricsOptions.destinationType;
       this.destinationId = getMetricsOptions.destinationId;
       this.subscriptionId = getMetricsOptions.subscriptionId;
       this.sourceId = getMetricsOptions.sourceId;
@@ -81,13 +85,11 @@ public class GetMetricsOptions extends GenericModel {
      * Instantiates a new builder with required properties.
      *
      * @param instanceId the instanceId
-     * @param destinationType the destinationType
      * @param gte the gte
      * @param lte the lte
      */
-    public Builder(String instanceId, String destinationType, String gte, String lte) {
+    public Builder(String instanceId, String gte, String lte) {
       this.instanceId = instanceId;
-      this.destinationType = destinationType;
       this.gte = gte;
       this.lte = lte;
     }
@@ -113,17 +115,6 @@ public class GetMetricsOptions extends GenericModel {
     }
 
     /**
-     * Set the destinationType.
-     *
-     * @param destinationType the destinationType
-     * @return the GetMetricsOptions builder
-     */
-    public Builder destinationType(String destinationType) {
-      this.destinationType = destinationType;
-      return this;
-    }
-
-    /**
      * Set the gte.
      *
      * @param gte the gte
@@ -142,6 +133,28 @@ public class GetMetricsOptions extends GenericModel {
      */
     public Builder lte(String lte) {
       this.lte = lte;
+      return this;
+    }
+
+    /**
+     * Set the smtpConfigId.
+     *
+     * @param smtpConfigId the smtpConfigId
+     * @return the GetMetricsOptions builder
+     */
+    public Builder smtpConfigId(String smtpConfigId) {
+      this.smtpConfigId = smtpConfigId;
+      return this;
+    }
+
+    /**
+     * Set the destinationType.
+     *
+     * @param destinationType the destinationType
+     * @return the GetMetricsOptions builder
+     */
+    public Builder destinationType(String destinationType) {
+      this.destinationType = destinationType;
       return this;
     }
 
@@ -217,16 +230,15 @@ public class GetMetricsOptions extends GenericModel {
   protected GetMetricsOptions(Builder builder) {
     com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.instanceId,
       "instanceId cannot be empty");
-    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.destinationType,
-      "destinationType cannot be null");
     com.ibm.cloud.sdk.core.util.Validator.notNull(builder.gte,
       "gte cannot be null");
     com.ibm.cloud.sdk.core.util.Validator.notNull(builder.lte,
       "lte cannot be null");
     instanceId = builder.instanceId;
-    destinationType = builder.destinationType;
     gte = builder.gte;
     lte = builder.lte;
+    smtpConfigId = builder.smtpConfigId;
+    destinationType = builder.destinationType;
     destinationId = builder.destinationId;
     subscriptionId = builder.subscriptionId;
     sourceId = builder.sourceId;
@@ -256,17 +268,6 @@ public class GetMetricsOptions extends GenericModel {
   }
 
   /**
-   * Gets the destinationType.
-   *
-   * Destination type. Allowed values are [smtp_custom].
-   *
-   * @return the destinationType
-   */
-  public String destinationType() {
-    return destinationType;
-  }
-
-  /**
    * Gets the gte.
    *
    * GTE (greater than equal), start timestamp in UTC.
@@ -286,6 +287,29 @@ public class GetMetricsOptions extends GenericModel {
    */
   public String lte() {
     return lte;
+  }
+
+  /**
+   * Gets the smtpConfigId.
+   *
+   * SMTP configuration ID. Required when querying metrics for SMTP interface destinations.
+   *
+   * @return the smtpConfigId
+   */
+  public String smtpConfigId() {
+    return smtpConfigId;
+  }
+
+  /**
+   * Gets the destinationType.
+   *
+   * Destination type for which metrics are requested. Supported value: smtp_custom. Required when querying metrics for
+   * custom email destinations.
+   *
+   * @return the destinationType
+   */
+  public String destinationType() {
+    return destinationType;
   }
 
   /**

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsIT.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsIT.java
@@ -4446,10 +4446,10 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test2LTestMetrics(){
+  public void test2LTestMetricsWithDestinationType(){
 
     try{
-      Instant instant = Instant.now();
+      Instant instant = Instant.now().minus(Duration.ofMinutes(5));
       String d1 = instant.toString();
 
       GetMetricsOptions getMetricsOptionsModel = new GetMetricsOptions.Builder()
@@ -4462,7 +4462,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
       .emailTo("mobileb@us.ibm.com")
       .sourceId(sourceId)
       .notificationId(notificationID)
-      .subject("Metric Test")
+      .subject("Metric Test With destination type")
       .build();
 
     // Invoke getMetrics() with a valid options model and verify the result
@@ -4479,10 +4479,42 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
 
   }
 
-  @Test
-  public void test2MTestBounceMetrics(){
+@Test
+  public void test2MTestMetricsWithSmtpConfigID(){
     try{
       Instant instant = Instant.now();
+      String d1 = instant.toString();
+
+      GetMetricsOptions getMetricsOptionsModel = new GetMetricsOptions.Builder()
+              .instanceId(instanceId)
+              .smtpConfigId(smtpConfigID)
+              .gte(instant.minus(Duration.ofDays(1)).toString())
+              .lte(d1)
+              .subscriptionId(subscriptionId16)
+              .emailTo("mobileb@us.ibm.com")
+              .sourceId(sourceId)
+              .notificationId(notificationID)
+              .subject("Metric Test with smtp config id")
+              .build();
+
+      // Invoke getMetrics() with a valid options model and verify the result
+      Response<Metrics> response = service.getMetrics(getMetricsOptionsModel).execute();
+      assertNotNull(response);
+      assertEquals(response.getStatusCode(), 200);
+      Metrics responseObj = response.getResult();
+      assertNotNull(responseObj);
+    }
+    catch(ServiceResponseException e){
+      fail(String.format("Service returned status code %d: %s%nError details: %s",
+              e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+    }
+
+  }
+
+  @Test
+  public void test2NTestBounceMetricsWithDestinationType(){
+    try{
+      Instant instant = Instant.now().minus(Duration.ofMinutes(5));
       String d1 = instant.toString();
 
       GetBounceMetricsOptions getBounceMetricsOptionsModel = new GetBounceMetricsOptions.Builder()
@@ -4495,7 +4527,38 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
               .emailTo("mobileb@us.ibm.com")
               .notificationId(notificationID)
               .sourceId(sourceId)
-              .subject("Bounce Metrics")
+              .subject("Bounce Metrics with destination type")
+              .build();
+
+      // Invoke getBounceMetrics() with a valid options model and verify the result
+      Response<BounceMetrics> response = service.getBounceMetrics(getBounceMetricsOptionsModel).execute();
+      assertNotNull(response);
+      assertEquals(response.getStatusCode(), 200);
+      BounceMetrics responseObj = response.getResult();
+      assertNotNull(responseObj);
+    }
+    catch(ServiceResponseException e){
+      fail(String.format("Service returned status code %d: %s%nError details: %s",
+              e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+    }
+  }
+
+@Test
+  public void test2OTestBounceMetricsWithSMTPConfigID(){
+    try{
+      Instant instant = Instant.now();
+      String d1 = instant.toString();
+
+      GetBounceMetricsOptions getBounceMetricsOptionsModel = new GetBounceMetricsOptions.Builder()
+              .instanceId(instanceId)
+              .smtpConfigId(smtpConfigID)
+              .gte(instant.minus(Duration.ofDays(1)).toString())
+              .lte(d1)
+              .subscriptionId(subscriptionId16)
+              .emailTo("mobileb@us.ibm.com")
+              .notificationId(notificationID)
+              .sourceId(sourceId)
+              .subject("Bounce Metrics with smtp config id")
               .build();
 
       // Invoke getBounceMetrics() with a valid options model and verify the result
@@ -4512,7 +4575,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test2NTestListPredefinedTemplates(){
+  public void test2PTestListPredefinedTemplates(){
 
     try{
       ListPreDefinedTemplatesOptions listPreDefinedTemplatesOptionsModel = new ListPreDefinedTemplatesOptions.Builder()
@@ -4536,7 +4599,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test2OTestGetPredefinedTemplate(){
+  public void test2QTestGetPredefinedTemplate(){
 
     try{
       GetPreDefinedTemplateOptions getPreDefinedTemplateOptionsModel = new GetPreDefinedTemplateOptions.Builder()
@@ -4558,7 +4621,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test2PDeleteSubscription() throws Exception {
+  public void test2RDeleteSubscription() throws Exception {
     try {
 
       List<String> subscriptions = new ArrayList<>();
@@ -4615,7 +4678,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test2QDeleteTopic() throws Exception {
+  public void test2SDeleteTopic() throws Exception {
     try {
 
       List<String> topics = new ArrayList<>();
@@ -4654,7 +4717,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test2RDeleteDestination() throws Exception {
+  public void test2TDeleteDestination() throws Exception {
     try {
       List<String> destinations = new ArrayList<>();
       destinations.add(destinationId);
@@ -4708,7 +4771,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test2SDeleteSource() throws Exception {
+  public void test2UDeleteSource() throws Exception {
     try {
       DeleteSourceOptions deleteSourceOptions = new DeleteSourceOptions.Builder()
               .instanceId(instanceId)
@@ -4738,7 +4801,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test2TCreateIntegration() throws Exception {
+  public void test2VCreateIntegration() throws Exception {
     try {
       IntegrationCreateMetadata metadata = new IntegrationCreateMetadata.Builder()
               .endpoint(cosEndPoint)
@@ -4766,7 +4829,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test2UListIntegrations() throws Exception {
+  public void test2WListIntegrations() throws Exception {
     try {
       int limit = 1;
       int offset = 0;
@@ -4793,7 +4856,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test2VGetIntegration() throws Exception {
+  public void test2XGetIntegration() throws Exception {
     try {
       GetIntegrationOptions integrationsOptions = new GetIntegrationOptions.Builder()
               .instanceId(instanceId)
@@ -4813,7 +4876,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test2WUpdateIntegration() throws Exception {
+  public void test2YUpdateIntegration() throws Exception {
     try {
       IntegrationMetadata metadata = new IntegrationMetadata.Builder()
               .endpoint(cosEndPoint)
@@ -4841,7 +4904,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
   }
 
   @Test
-  public void test2XDeleteTemplate() throws Exception {
+  public void test2ZDeleteTemplate() throws Exception {
     try {
      List<String> templates = new ArrayList<>();
      templates.add(templateInvitationID);
@@ -4872,7 +4935,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
     }
   }
   @Test
-  public void test2YDeleteSMTPUser() throws Exception {
+  public void test3ADeleteSMTPUser() throws Exception {
     try {
       List<String> users = new ArrayList<>();
       users.add(smtpUserID);
@@ -4895,7 +4958,7 @@ public class EventNotificationsIT extends SdkIntegrationTestBase {
     }
   }
   @Test
-  public void test2ZDeleteSMTPConfiguration() throws Exception {
+  public void test3BDeleteSMTPConfiguration() throws Exception {
     try {
       List<String> smtpConfigIDs = new ArrayList<>();
       smtpConfigIDs.add(smtpConfigID);

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsTest.java
@@ -277,9 +277,10 @@ public class EventNotificationsTest {
     // Construct an instance of the GetMetricsOptions model
     GetMetricsOptions getMetricsOptionsModel = new GetMetricsOptions.Builder()
       .instanceId("testString")
-      .destinationType("smtp_custom")
       .gte("testString")
       .lte("testString")
+      .smtpConfigId("testString")
+      .destinationType("smtp_custom")
       .destinationId("testString")
       .subscriptionId("testString")
       .sourceId("testString")
@@ -304,9 +305,10 @@ public class EventNotificationsTest {
     // Verify query params
     Map<String, String> query = TestUtilities.parseQueryString(request);
     assertNotNull(query);
-    assertEquals(query.get("destination_type"), "smtp_custom");
     assertEquals(query.get("gte"), "testString");
     assertEquals(query.get("lte"), "testString");
+    assertEquals(query.get("smtp_config_id"), "testString");
+    assertEquals(query.get("destination_type"), "smtp_custom");
     assertEquals(query.get("destination_id"), "testString");
     assertEquals(query.get("subscription_id"), "testString");
     assertEquals(query.get("source_id"), "testString");
@@ -346,9 +348,10 @@ public class EventNotificationsTest {
     // Construct an instance of the GetBounceMetricsOptions model
     GetBounceMetricsOptions getBounceMetricsOptionsModel = new GetBounceMetricsOptions.Builder()
       .instanceId("testString")
-      .destinationType("smtp_custom")
       .gte("testString")
       .lte("testString")
+      .smtpConfigId("testString")
+      .destinationType("smtp_custom")
       .destinationId("testString")
       .subscriptionId("testString")
       .sourceId("testString")
@@ -375,9 +378,10 @@ public class EventNotificationsTest {
     // Verify query params
     Map<String, String> query = TestUtilities.parseQueryString(request);
     assertNotNull(query);
-    assertEquals(query.get("destination_type"), "smtp_custom");
     assertEquals(query.get("gte"), "testString");
     assertEquals(query.get("lte"), "testString");
+    assertEquals(query.get("smtp_config_id"), "testString");
+    assertEquals(query.get("destination_type"), "smtp_custom");
     assertEquals(query.get("destination_id"), "testString");
     assertEquals(query.get("subscription_id"), "testString");
     assertEquals(query.get("source_id"), "testString");

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetBounceMetricsOptionsTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetBounceMetricsOptionsTest.java
@@ -33,9 +33,10 @@ public class GetBounceMetricsOptionsTest {
   public void testGetBounceMetricsOptions() throws Throwable {
     GetBounceMetricsOptions getBounceMetricsOptionsModel = new GetBounceMetricsOptions.Builder()
       .instanceId("testString")
-      .destinationType("smtp_custom")
       .gte("testString")
       .lte("testString")
+      .smtpConfigId("testString")
+      .destinationType("smtp_custom")
       .destinationId("testString")
       .subscriptionId("testString")
       .sourceId("testString")
@@ -46,9 +47,10 @@ public class GetBounceMetricsOptionsTest {
       .offset(Long.valueOf("0"))
       .build();
     assertEquals(getBounceMetricsOptionsModel.instanceId(), "testString");
-    assertEquals(getBounceMetricsOptionsModel.destinationType(), "smtp_custom");
     assertEquals(getBounceMetricsOptionsModel.gte(), "testString");
     assertEquals(getBounceMetricsOptionsModel.lte(), "testString");
+    assertEquals(getBounceMetricsOptionsModel.smtpConfigId(), "testString");
+    assertEquals(getBounceMetricsOptionsModel.destinationType(), "smtp_custom");
     assertEquals(getBounceMetricsOptionsModel.destinationId(), "testString");
     assertEquals(getBounceMetricsOptionsModel.subscriptionId(), "testString");
     assertEquals(getBounceMetricsOptionsModel.sourceId(), "testString");

--- a/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetMetricsOptionsTest.java
+++ b/modules/event-notifications/src/test/java/com/ibm/cloud/eventnotifications/event_notifications/v1/model/GetMetricsOptionsTest.java
@@ -33,9 +33,10 @@ public class GetMetricsOptionsTest {
   public void testGetMetricsOptions() throws Throwable {
     GetMetricsOptions getMetricsOptionsModel = new GetMetricsOptions.Builder()
       .instanceId("testString")
-      .destinationType("smtp_custom")
       .gte("testString")
       .lte("testString")
+      .smtpConfigId("testString")
+      .destinationType("smtp_custom")
       .destinationId("testString")
       .subscriptionId("testString")
       .sourceId("testString")
@@ -44,9 +45,10 @@ public class GetMetricsOptionsTest {
       .subject("testString")
       .build();
     assertEquals(getMetricsOptionsModel.instanceId(), "testString");
-    assertEquals(getMetricsOptionsModel.destinationType(), "smtp_custom");
     assertEquals(getMetricsOptionsModel.gte(), "testString");
     assertEquals(getMetricsOptionsModel.lte(), "testString");
+    assertEquals(getMetricsOptionsModel.smtpConfigId(), "testString");
+    assertEquals(getMetricsOptionsModel.destinationType(), "smtp_custom");
     assertEquals(getMetricsOptionsModel.destinationId(), "testString");
     assertEquals(getMetricsOptionsModel.subscriptionId(), "testString");
     assertEquals(getMetricsOptionsModel.sourceId(), "testString");

--- a/modules/examples/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsExamples.java
+++ b/modules/examples/src/main/java/com/ibm/cloud/eventnotifications/event_notifications/v1/EventNotificationsExamples.java
@@ -2681,9 +2681,34 @@ public class EventNotificationsExamples {
       // begin-metrics
       GetMetricsOptions getMetricsOptionsModel = new GetMetricsOptions.Builder()
                 .instanceId(instanceId)
+                .gte("2026-06-01T17:18:43Z")
+                .lte("2026-06-02T11:55:22Z")
+                .smtpConfigId(smtpConfigID)
+                .subscriptionId(subscriptionId6)
+                .emailTo("mobileb@us.ibm.com")
+                .sourceId(sourceId)
+                .notificationId(notificationID)
+                .subject("Metric Test")
+                .build();
+
+        // Invoke getMetrics() with a valid options model and verify the result
+      Response<Metrics> response = eventNotificationsService.getMetrics(getMetricsOptionsModel).execute();
+
+      Metrics responseObj = response.getResult();
+      System.out.println(responseObj);
+      // end-metrics
+    } catch (ServiceResponseException e) {
+      logger.error(String.format("Service returned status code %s: %s%nError details: %s",
+              e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+    }
+
+    try {
+      // begin-metrics
+      GetMetricsOptions getMetricsOptionsModel = new GetMetricsOptions.Builder()
+                .instanceId(instanceId)
                 .destinationType("smtp_custom")
-                .gte("2024-08-01T17:18:43Z")
-                .lte("2024-08-02T11:55:22Z")
+                .gte("2026-06-01T17:18:43Z")
+                .lte("2026-06-02T11:55:22Z")
                 .destinationId(destinationId16)
                 .subscriptionId(subscriptionId6)
                 .emailTo("mobileb@us.ibm.com")
@@ -2708,9 +2733,33 @@ public class EventNotificationsExamples {
       GetBounceMetricsOptions getBounceMetricsOptionsModel = new GetBounceMetricsOptions.Builder()
               .instanceId(instanceId)
               .destinationType("smtp_custom")
-              .gte("2025-12-08T17:18:43Z")
-              .lte("2025-12-09T11:55:22Z")
+              .gte("2026-06-08T17:18:43Z")
+              .lte("2026-06-09T11:55:22Z")
               .destinationId(destinationId16)
+              .subscriptionId(subscriptionId6)
+              .emailTo("mobileb@us.ibm.com")
+              .notificationId(notificationID)
+              .sourceId(sourceId)
+              .subject("Bounce Metrics")
+              .build();
+
+      // Invoke getMetrics() with a valid options model and verify the result
+      Response<BounceMetrics> response = eventNotificationsService.getBounceMetrics(getBounceMetricsOptionsModel).execute();
+
+      BounceMetrics responseObj = response.getResult();
+      System.out.println(responseObj);
+      // end-bounce-metrics
+    } catch (ServiceResponseException e) {
+      logger.error(String.format("Service returned status code %s: %s%nError details: %s",
+              e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+    }
+    try {
+      // begin-bounce-metrics
+      GetBounceMetricsOptions getBounceMetricsOptionsModel = new GetBounceMetricsOptions.Builder()
+              .instanceId(instanceId)
+              .gte("2026-06-08T17:18:43Z")
+              .lte("2026-06-09T11:55:22Z")
+              .smtpConfigId(smtpConfigID)
               .subscriptionId(subscriptionId6)
               .emailTo("mobileb@us.ibm.com")
               .notificationId(notificationID)


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->

**Fixes:** https://github.ibm.com/Notification-Hub/planning/issues/19982

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
For the GET /metrics API current documentation states that destination_type is a mandatory parameter for retrieving metrics. However, this is not accurate, as metrics can be retrieved without always providing destination_type.
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
For the GET /metrics API, users can provide either destination_type or smtp_config_id to retrieve metrics. Supplying both parameters is not required.
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->